### PR TITLE
Fixed NaN equals failing for DoubleTag and FloatTag

### DIFF
--- a/src/main/java/net/querz/nbt/DoubleTag.java
+++ b/src/main/java/net/querz/nbt/DoubleTag.java
@@ -43,7 +43,7 @@ public class DoubleTag extends NumberTag<Double> {
 
 	@Override
 	public boolean equals(Object other) {
-		return super.equals(other) && asDouble() == ((DoubleTag) other).asDouble();
+		return super.equals(other) && Double.valueOf(asDouble()).equals(((DoubleTag) other).asDouble());
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/FloatTag.java
+++ b/src/main/java/net/querz/nbt/FloatTag.java
@@ -43,7 +43,7 @@ public class FloatTag extends NumberTag<Float> {
 
 	@Override
 	public boolean equals(Object other) {
-		return super.equals(other) && asFloat() == ((FloatTag) other).asFloat();
+		return super.equals(other) && Float.valueOf(asFloat()).equals(((FloatTag) other).asFloat());
 	}
 
 	@Override

--- a/src/test/java/net/querz/nbt/DoubleTagTest.java
+++ b/src/test/java/net/querz/nbt/DoubleTagTest.java
@@ -1,5 +1,7 @@
 package net.querz.nbt;
 
+import static org.junit.Assert.assertNotEquals;
+
 import java.util.Arrays;
 
 public class DoubleTagTest extends NBTTestCase {
@@ -14,10 +16,9 @@ public class DoubleTagTest extends NBTTestCase {
 
 	public void testEquals() {
 		DoubleTag t = new DoubleTag(Double.MAX_VALUE);
-		DoubleTag t2 = new DoubleTag(Double.MAX_VALUE);
-		assertTrue(t.equals(t2));
-		DoubleTag t3 = new DoubleTag(Double.MIN_VALUE);
-		assertFalse(t.equals(t3));
+		assertEquals(t, new DoubleTag(Double.MAX_VALUE));
+		assertNotEquals(t, new DoubleTag(Double.MIN_VALUE));
+		assertEquals(new DoubleTag(Double.NaN), new DoubleTag(Double.NaN));
 	}
 
 	public void testClone() {

--- a/src/test/java/net/querz/nbt/FloatTagTest.java
+++ b/src/test/java/net/querz/nbt/FloatTagTest.java
@@ -1,5 +1,7 @@
 package net.querz.nbt;
 
+import static org.junit.Assert.assertNotEquals;
+
 import java.util.Arrays;
 
 public class FloatTagTest extends NBTTestCase {
@@ -14,10 +16,9 @@ public class FloatTagTest extends NBTTestCase {
 
 	public void testEquals() {
 		FloatTag t = new FloatTag(Float.MAX_VALUE);
-		FloatTag t2 = new FloatTag(Float.MAX_VALUE);
-		assertTrue(t.equals(t2));
-		FloatTag t3 = new FloatTag(Float.MIN_VALUE);
-		assertFalse(t.equals(t3));
+		assertEquals(t, new FloatTag(Float.MAX_VALUE));
+		assertNotEquals(t, new FloatTag(Float.MIN_VALUE));
+		assertEquals(new FloatTag(Float.NaN), new FloatTag(Float.NaN));
 	}
 
 	public void testClone() {


### PR DESCRIPTION
DoubleTag and FloatTag equals methods used to compare primitive values using `==` which fails for NaN
Using equals methods of wrapper classes now