### PR TITLE
All tags should implement hashCode()

### DIFF
--- a/src/main/java/net/querz/nbt/ByteArrayTag.java
+++ b/src/main/java/net/querz/nbt/ByteArrayTag.java
@@ -50,6 +50,11 @@ public class ByteArrayTag extends ArrayTag<byte[]> {
 	}
 
 	@Override
+	public int hashCode() {
+		return Arrays.hashCode(getValue());
+	}
+
+	@Override
 	public ByteArrayTag clone() {
 		return new ByteArrayTag(Arrays.copyOf(getValue(), length()));
 	}

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -291,9 +291,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 
 	@Override
 	public int hashCode() {
-		int keyHash = Objects.hash(getValue().keySet().toArray());
-		int valueHash = Objects.hash(values().toArray());
-		return Objects.hash(keyHash, valueHash);
+		return Objects.hash(entrySet().toArray());
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -3,11 +3,7 @@ package net.querz.nbt;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiConsumer;
 
 public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.Entry<String, Tag>> {
@@ -291,6 +287,13 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 			}
 		}
 		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int keyHash = Objects.hash(getValue().keySet().toArray());
+		int valueHash = Objects.hash(values().toArray());
+		return Objects.hash(keyHash, valueHash);
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/EndTag.java
+++ b/src/main/java/net/querz/nbt/EndTag.java
@@ -45,7 +45,7 @@ public final class EndTag extends Tag<Void> {
 	}
 
 	@Override
-	protected EndTag clone() {
+	public EndTag clone() {
 		return INSTANCE;
 	}
 }

--- a/src/main/java/net/querz/nbt/IntArrayTag.java
+++ b/src/main/java/net/querz/nbt/IntArrayTag.java
@@ -54,6 +54,11 @@ public class IntArrayTag extends ArrayTag<int[]> {
 	}
 
 	@Override
+	public int hashCode() {
+		return Arrays.hashCode(getValue());
+	}
+
+	@Override
 	public IntArrayTag clone() {
 		return new IntArrayTag(Arrays.copyOf(getValue(), length()));
 	}

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -3,11 +3,7 @@ package net.querz.nbt;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.function.Consumer;
 
 public class ListTag<T extends Tag> extends Tag<List<T>> implements Iterable<T> {
@@ -309,6 +305,11 @@ public class ListTag<T extends Tag> extends Tag<List<T>> implements Iterable<T> 
 			}
 		}
 		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getValue().toArray());
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/LongArrayTag.java
+++ b/src/main/java/net/querz/nbt/LongArrayTag.java
@@ -54,6 +54,11 @@ public class LongArrayTag extends ArrayTag<long[]> {
 	}
 
 	@Override
+	public int hashCode() {
+		return Arrays.hashCode(getValue());
+	}
+
+	@Override
 	public LongArrayTag clone() {
 		return new LongArrayTag(Arrays.copyOf(getValue(), length()));
 	}

--- a/src/main/java/net/querz/nbt/Tag.java
+++ b/src/main/java/net/querz/nbt/Tag.java
@@ -199,12 +199,17 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 		return other != null && getClass() == other.getClass();
 	}
 
+	@Override
+	public int hashCode() {
+		return value.hashCode();
+	}
+
 	/**
 	 * Creates a clone of this Tag.
 	 * @return A clone of this Tag.
 	 * */
 	@SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
-	protected abstract Tag clone();
+	public abstract Tag clone();
 
 	/**
 	 * A utility method to check if some value is null.

--- a/src/main/java/net/querz/nbt/custom/ObjectTag.java
+++ b/src/main/java/net/querz/nbt/custom/ObjectTag.java
@@ -2,12 +2,8 @@ package net.querz.nbt.custom;
 
 import net.querz.nbt.Tag;
 import net.querz.nbt.TagFactory;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
+
+import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 
 public class ObjectTag<T extends Serializable> extends Tag<T> {
@@ -58,7 +54,7 @@ public class ObjectTag<T extends Serializable> extends Tag<T> {
 	public void deserializeValue(DataInputStream dis, int depth) throws IOException {
 		try {
 			setValue((T) new ObjectInputStream(dis).readObject());
-		} catch (ClassNotFoundException e) {
+		} catch (InvalidClassException | ClassNotFoundException e) {
 			throw new IOException(e.getCause());
 		}
 	}
@@ -79,6 +75,11 @@ public class ObjectTag<T extends Serializable> extends Tag<T> {
 				&& (getValue() == ((ObjectTag) other).getValue()
 				|| getValue() != null
 				&& getValue().equals(((ObjectTag<?>) other).getValue()));
+	}
+
+	@Override
+	public int hashCode() {
+		return getValue().hashCode();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/net/querz/nbt/custom/ShortArrayTag.java
+++ b/src/main/java/net/querz/nbt/custom/ShortArrayTag.java
@@ -60,6 +60,11 @@ public class ShortArrayTag extends ArrayTag<short[]> {
 	}
 
 	@Override
+	public int hashCode() {
+		return Arrays.hashCode(getValue());
+	}
+
+	@Override
 	public ShortArrayTag clone() {
 		return new ShortArrayTag(Arrays.copyOf(getValue(), length()));
 	}

--- a/src/main/java/net/querz/nbt/custom/StructTag.java
+++ b/src/main/java/net/querz/nbt/custom/StructTag.java
@@ -17,10 +17,7 @@ import net.querz.nbt.TagFactory;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.function.Consumer;
 
 public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
@@ -287,6 +284,11 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 	}
 
 	@Override
+	public int hashCode() {
+		return Objects.hash(getValue().toArray());
+	}
+
+	@Override
 	public int compareTo(Tag<List<Tag>> o) {
 		if (!(o instanceof StructTag)) {
 			return 0;
@@ -298,7 +300,7 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 	public StructTag clone() {
 		StructTag copy = new StructTag();
 		for (Tag tag : getValue()) {
-			copy.add(tag);
+			copy.add(tag.clone());
 		}
 		return copy;
 	}

--- a/src/test/java/net/querz/nbt/CompoundTagTest.java
+++ b/src/test/java/net/querz/nbt/CompoundTagTest.java
@@ -1,10 +1,9 @@
 package net.querz.nbt;
 
-import junit.framework.TestCase;
-
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import static org.junit.Assert.assertNotEquals;
 
 public class CompoundTagTest extends NBTTestCase {
 
@@ -48,6 +47,89 @@ public class CompoundTagTest extends NBTTestCase {
 		assertFalse(ct.equals("blah"));
 
 		assertEquals(ct, ct);
+	}
+
+	public void testHashCode() {
+		CompoundTag t = new CompoundTag();
+		for (int i = 0; i < 256; i++) {
+			t.putByte("key_byte" + i, (byte) i);
+			t.putShort("key_short" + i, (short) i);
+			t.putInt("key_int" + i, i);
+			t.putLong("key_long" + i, i);
+			t.putFloat("key_float" + i, i * 1.001f);
+			t.putDouble("key_double" + i, i * 1.001);
+			t.putString("key_string" + i, "value" + i);
+
+			byte[] bArray = new byte[257];
+			int[] iArray = new int[257];
+			long[] lArray = new long[257];
+			for (byte b = -128; b < 127; b++) {
+				bArray[b + 128] = b;
+				iArray[b + 128] = b;
+				lArray[b + 128] = b;
+			}
+			bArray[256] = (byte) i;
+			iArray[256] = i;
+			lArray[256] = i;
+			t.putByteArray("key_byte_array" + i, bArray);
+			t.putIntArray("key_int_array" + i, iArray);
+			t.putLongArray("key_long_array" + i, lArray);
+
+			ListTag<StringTag> l = new ListTag<>();
+			for (int j = 0; j < 256; j++) {
+				l.addString("value" + j);
+			}
+			l.addString("value" + i);
+			t.put("key_list" + i, l);
+
+			CompoundTag c = new CompoundTag();
+			c.putString("key_string" + i, "value" + i);
+			t.put("key_child" + i, c);
+		}
+		CompoundTag t2 = new CompoundTag();
+		for (int i = 0; i < 256; i++) {
+			t2.putString("key_string" + i, "value" + i);
+			t2.putDouble("key_double" + i, i * 1.001);
+			t2.putFloat("key_float" + i, i * 1.001f);
+			t2.putLong("key_long" + i, i);
+			t2.putInt("key_int" + i, i);
+			t2.putShort("key_short" + i, (short) i);
+			t2.putByte("key_byte" + i, (byte) i);
+
+			byte[] bArray = new byte[257];
+			int[] iArray = new int[257];
+			long[] lArray = new long[257];
+			for (byte b = -128; b < 127; b++) {
+				bArray[b + 128] = b;
+				iArray[b + 128] = b;
+				lArray[b + 128] = b;
+			}
+			bArray[256] = (byte) i;
+			iArray[256] = i;
+			lArray[256] = i;
+			t2.putByteArray("key_byte_array" + i, bArray);
+			t2.putIntArray("key_int_array" + i, iArray);
+			t2.putLongArray("key_long_array" + i, lArray);
+
+			ListTag<StringTag> l = new ListTag<>();
+			for (int j = 0; j < 256; j++) {
+				l.addString("value" + j);
+			}
+			l.addString("value" + i);
+			t2.put("key_list" + i, l);
+
+			CompoundTag c = new CompoundTag();
+			c.putString("key_string" + i, "value" + i);
+			t2.put("key_child" + i, c);
+		}
+
+		assertEquals(t, t2);
+		assertEquals(t.hashCode(), t2.hashCode());
+
+		t.getCompoundTag("key_child1").remove("key_string1");
+
+		assertNotEquals(t, t2);
+		assertNotEquals(t.hashCode(), t2.hashCode());
 	}
 
 	public void testClone() {

--- a/src/test/java/net/querz/nbt/TagFactoryTest.java
+++ b/src/test/java/net/querz/nbt/TagFactoryTest.java
@@ -77,7 +77,7 @@ public class TagFactoryTest extends NBTTestCase {
 		}
 
 		@Override
-		protected InvalidCustomTag clone() {
+		public InvalidCustomTag clone() {
 			return null;
 		}
 

--- a/src/test/java/net/querz/nbt/custom/ObjectTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/ObjectTagTest.java
@@ -3,11 +3,10 @@ package net.querz.nbt.custom;
 import net.querz.nbt.NBTTestCase;
 import net.querz.nbt.NBTUtil;
 import net.querz.nbt.TagFactory;
-
-import java.io.File;
+import static org.junit.Assert.assertNotEquals;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Arrays;
+import java.util.Objects;
 import java.util.Random;
 
 public class ObjectTagTest extends NBTTestCase implements Serializable {
@@ -29,6 +28,15 @@ public class ObjectTagTest extends NBTTestCase implements Serializable {
 		assertFalse(o.equals(o3));
 		ObjectTag<DummyObject> o4 = new ObjectTag<>(d.clone());
 		assertTrue(o.equals(o4));
+	}
+
+	public void testHashCode() {
+		DummyObject d = new DummyObject();
+		DummyObject d2 = new DummyObject();
+		ObjectTag<DummyObject> o = new ObjectTag<>(d);
+		ObjectTag<DummyObject> o2 = new ObjectTag<>(d2);
+		assertNotEquals(o.hashCode(), o2.hashCode());
+		assertEquals(o.hashCode(), o.clone().hashCode());
 	}
 
 	public void testClone() {
@@ -156,6 +164,11 @@ public class ObjectTagTest extends NBTTestCase implements Serializable {
 						&& t.f == f;
 			}
 			return false;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(a, b, c, d, e, f);
 		}
 	}
 }

--- a/src/test/java/net/querz/nbt/custom/ShortArrayTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/ShortArrayTagTest.java
@@ -2,6 +2,7 @@ package net.querz.nbt.custom;
 
 import net.querz.nbt.NBTTestCase;
 import java.util.Arrays;
+import static org.junit.Assert.assertNotEquals;
 
 public class ShortArrayTagTest extends NBTTestCase {
 
@@ -19,6 +20,13 @@ public class ShortArrayTagTest extends NBTTestCase {
 		assertTrue(t.equals(t2));
 		ShortArrayTag t3 = new ShortArrayTag(new short[]{Short.MAX_VALUE, 0, Short.MIN_VALUE});
 		assertFalse(t.equals(t3));
+	}
+
+	public void testHashCode() {
+		ShortArrayTag t = new ShortArrayTag(new short[]{Short.MIN_VALUE, 0, Short.MAX_VALUE});
+		ShortArrayTag t2 = new ShortArrayTag(new short[]{Short.MAX_VALUE, 0, Short.MIN_VALUE});
+		assertNotEquals(t.hashCode(), t2.hashCode());
+		assertEquals(t.hashCode(), t.clone().hashCode());
 	}
 
 	public void testClone() {

--- a/src/test/java/net/querz/nbt/custom/StructTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/StructTagTest.java
@@ -10,6 +10,7 @@ import net.querz.nbt.NBTTestCase;
 import net.querz.nbt.StringTag;
 import net.querz.nbt.Tag;
 import java.util.Arrays;
+import static org.junit.Assert.assertNotEquals;
 
 public class StructTagTest extends NBTTestCase {
 
@@ -43,6 +44,15 @@ public class StructTagTest extends NBTTestCase {
 		StructTag s4 = new StructTag();
 		s4.add(new ByteTag(Byte.MAX_VALUE));
 		assertFalse(s.equals(s4));
+	}
+
+	public void testHashCode() {
+		StructTag s = createStructTag();
+		StructTag s2 = createStructTag();
+		s2.addInt(123);
+		assertNotEquals(s.hashCode(), s2.hashCode());
+		assertEquals(s.hashCode(), s.clone().hashCode());
+
 	}
 
 	public void testClone() {


### PR DESCRIPTION
As all Tags override `equals()`, they must also override `hashCode()` correctly.
See #15 