### PR TITLE
Improve overall type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ ct.put("byte", new ByteTag((byte) 1));
 ct.put("double", new DoubleTag(1.234));
 ct.putString("string", "stringValue");
 ```
-An example on how to use `ListTag`:
+An example how to use a `ListTag`:
 ```java
-ListTag<FloatTag> fl = new ListTag<>();
+ListTag<FloatTag> fl = new ListTag<>(FloatTag.class);
 
 fl.add(new FloatTag(1.234f);
 fl.addFloat(5.678f);
@@ -66,15 +66,20 @@ Example usage:
 CompoundTag c = new CompoundTag();
 c.putByte("blah", (byte) 5);
 c.putString("foo", "bär");
-String s = c.toTagString();
+System.out.println(c.toTagString()); // {blah:5b,foo:"bär"}
 
-//output: {blah:5b,foo:"bär"}
+ListTag<StringTag> s = new ListTag<>(StringTag.class);
+s.addString("test");
+s.add(new StringTag("text"));
+c.add("list", s);
+System.out.println(c.toTagString()); // {blah:5b,foo:"bär",list:[test,text]}
+
 ```
-There are also some tools to read, change and write MCA files.
+There is also a tool to read, change and write MCA files.
 
 Here are some examples:
 ```java
-//This changes the InhabitedTime field of the chunk at x=68, z=81 to 0
+// This changes the InhabitedTime field of the chunk at x=68, z=81 to 0
 MCAFile mcaFile = MCAUtil.readMCAFile("r.2.2.mca");
 Chunk chunk = mcaFile.getChunk(68, 81);
 chunk.setInhabitedTime(0);
@@ -84,13 +89,13 @@ There is also an optimized api to retrieve and set block information (BlockState
 
 Example:
 ```java
-//Retrieves block information from the MCA file
+// Retrieves block information from the MCA file
 CompoundTag blockState = mcaFile.getBlockStateAt(1090, 25, 1301);
 
-//Retrieves block information from a single chunk
+// Retrieves block information from a single chunk
 CompoundTag blockState = chunk.getBlockStateAt(2, 25, 5);
 
-//Set block information
+// Set block information
 CompoundTag stone = new CompoundTag();
 stone.putString("Name", "minecraft:stone");
 mcaFile.setBlockStateAt(1090, 25, 1301, stone, false);
@@ -115,7 +120,7 @@ There are 4 example classes in `net.querz.nbt.custom` that show how to implement
 | [CharTag](src/main/java/net/querz/nbt/custom/CharTag.java)                | 110 | `Character` (char) tag. |
 | [StructTag](src/main/java/net/querz/nbt/custom/StructTag.java)            | 120 | Similar to the `ListTag`, but with the ability to store multiple types. |
 
-To be able to use a custom tag with deserialization, a `Supplier` must be registered at runtime alongside its id with `TagFactory.registerCustomTag()`. The `Supplier` can be anything that returns a new instance of this custom tag. Here is an example using the custom tags no-args constructor:
+To be able to use a custom tag with deserialization, a `Supplier` and the custom tag class must be registered at runtime alongside its id with `TagFactory.registerCustomTag()`. The `Supplier` can be anything that returns a new instance of this custom tag. Here is an example using the custom tags no-args constructor:
 ```java
-TagFactory.registerCustomTag(90, ObjectTag::new);
+TagFactory.registerCustomTag(90, ObjectTag::new, ObjectTag.class);
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ NBTUtil.writeTag(tag, "filename.dat");
 
 Example usage:
 ```java
-Tag tag = NBTUtil.readTag("filename.dat");
+Tag<?> tag = NBTUtil.readTag("filename.dat");
 ```
 #### Playing Minecraft?
 Each tag can be converted into a JSON-like NBT String used in Minecraft commands.

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'jacoco'
 
 group                        = 'net.querz.nbt'
 archivesBaseName             = 'nbt'
-version                      = '2.4'
+version                      = '3.0'
 sourceCompatibility          = '1.8'
 targetCompatibility          = '1.8'
 compileJava.options.encoding = 'UTF-8'

--- a/src/main/java/net/querz/nbt/ArrayTag.java
+++ b/src/main/java/net/querz/nbt/ArrayTag.java
@@ -9,10 +9,11 @@ import java.lang.reflect.Array;
  * */
 public abstract class ArrayTag<T> extends Tag<T> {
 
-	public ArrayTag() {}
-
 	public ArrayTag(T value) {
-		super(value);
+		if (!value.getClass().isArray()) {
+			throw new UnsupportedOperationException("type of array tag must be an array");
+		}
+		setValue(value);
 	}
 
 	public int length() {
@@ -31,7 +32,7 @@ public abstract class ArrayTag<T> extends Tag<T> {
 
 	@Override
 	public String valueToString(int depth) {
-		return arrayToString(getValue(), "", "");
+		return arrayToString("", "");
 	}
 
 	@Override
@@ -42,14 +43,10 @@ public abstract class ArrayTag<T> extends Tag<T> {
 		return Integer.compare(Array.getLength(getValue()), Array.getLength(other.getValue()));
 	}
 
-	protected String arrayToString(T array, String prefix, String suffix) {
-		if (array == null || !array.getClass().isArray()) {
-			throw new UnsupportedOperationException("cannot convert non-array to String");
-		}
-
+	protected String arrayToString(String prefix, String suffix) {
 		StringBuilder sb = new StringBuilder("[").append(prefix).append("".equals(prefix) ? "" : ";");
 		for (int i = 0; i < length(); i++) {
-			sb.append(i == 0 ? "" : ",").append(Array.get(array, i)).append(suffix);
+			sb.append(i == 0 ? "" : ",").append(Array.get(getValue(), i)).append(suffix);
 		}
 		sb.append("]");
 		return sb.toString();

--- a/src/main/java/net/querz/nbt/ArrayTag.java
+++ b/src/main/java/net/querz/nbt/ArrayTag.java
@@ -2,6 +2,11 @@ package net.querz.nbt;
 
 import java.lang.reflect.Array;
 
+/**
+ * ArrayTag is an abstract representation of any NBT array tag.
+ * For implementations see {@link ByteArrayTag}, {@link IntArrayTag}, {@link LongArrayTag}.
+ * @param <T> The array type.
+ * */
 public abstract class ArrayTag<T> extends Tag<T> {
 
 	public ArrayTag() {}

--- a/src/main/java/net/querz/nbt/ByteArrayTag.java
+++ b/src/main/java/net/querz/nbt/ByteArrayTag.java
@@ -14,11 +14,6 @@ public class ByteArrayTag extends ArrayTag<byte[]> {
 	}
 
 	@Override
-	public byte getID() {
-		return 7;
-	}
-
-	@Override
 	protected byte[] getEmptyValue() {
 		return new byte[0];
 	}

--- a/src/main/java/net/querz/nbt/ByteArrayTag.java
+++ b/src/main/java/net/querz/nbt/ByteArrayTag.java
@@ -7,7 +7,9 @@ import java.util.Arrays;
 
 public class ByteArrayTag extends ArrayTag<byte[]> {
 
-	public ByteArrayTag() {}
+	public ByteArrayTag() {
+		super(new byte[0]);
+	}
 
 	public ByteArrayTag(byte[] value) {
 		super(value);
@@ -33,7 +35,7 @@ public class ByteArrayTag extends ArrayTag<byte[]> {
 
 	@Override
 	public String valueToTagString(int depth) {
-		return arrayToString(getValue(), "B", "b");
+		return arrayToString("B", "b");
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/ByteTag.java
+++ b/src/main/java/net/querz/nbt/ByteTag.java
@@ -17,11 +17,6 @@ public class ByteTag extends NumberTag<Byte> {
 	}
 
 	@Override
-	public byte getID() {
-		return 1;
-	}
-
-	@Override
 	protected Byte getEmptyValue() {
 		return 0;
 	}

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -11,11 +11,6 @@ public class CompoundTag extends Tag<Map<String, Tag<?>>> implements Iterable<Ma
 	public CompoundTag() {}
 
 	@Override
-	public byte getID() {
-		return 10;
-	}
-
-	@Override
 	protected Map<String, Tag<?>> getEmptyValue() {
 		return new HashMap<>(8);
 	}

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.function.BiConsumer;
 
-public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.Entry<String, Tag>> {
+public class CompoundTag extends Tag<Map<String, Tag<?>>> implements Iterable<Map.Entry<String, Tag<?>>> {
 
 	public CompoundTag() {}
 
@@ -16,7 +16,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 	}
 
 	@Override
-	protected Map<String, Tag> getEmptyValue() {
+	protected Map<String, Tag<?>> getEmptyValue() {
 		return new HashMap<>(8);
 	}
 
@@ -24,7 +24,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 		return getValue().size();
 	}
 
-	public Tag remove(String key) {
+	public Tag<?> remove(String key) {
 		return getValue().remove(key);
 	}
 
@@ -36,11 +36,11 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 		return getValue().containsKey(key);
 	}
 
-	public boolean containsValue(Tag value) {
+	public boolean containsValue(Tag<?> value) {
 		return getValue().containsValue(value);
 	}
 
-	public Collection<Tag> values() {
+	public Collection<Tag<?>> values() {
 		return getValue().values();
 	}
 
@@ -48,28 +48,28 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 		return getValue().keySet();
 	}
 
-	public Set<Map.Entry<String, Tag>> entrySet() {
+	public Set<Map.Entry<String, Tag<?>>> entrySet() {
 		return new NonNullEntrySet<>(getValue().entrySet());
 	}
 
 	@Override
-	public Iterator<Map.Entry<String, Tag>> iterator() {
+	public Iterator<Map.Entry<String, Tag<?>>> iterator() {
 		return entrySet().iterator();
 	}
 
-	public void forEach(BiConsumer<String, Tag> action) {
+	public void forEach(BiConsumer<String, Tag<?>> action) {
 		getValue().forEach(action);
 	}
 
-	public <C extends Tag> C get(String key, Class<C> type) {
-		Tag t = getValue().get(key);
+	public <C extends Tag<?>> C get(String key, Class<C> type) {
+		Tag<?> t = getValue().get(key);
 		if (t != null) {
 			return type.cast(t);
 		}
 		return null;
 	}
 
-	public Tag get(String key) {
+	public Tag<?> get(String key) {
 		return getValue().get(key);
 	}
 
@@ -122,7 +122,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 	}
 
 	public boolean getBoolean(String key) {
-		Tag t = get(key);
+		Tag<?> t = get(key);
 		return t instanceof ByteTag && ((ByteTag) t).asByte() > 0;
 	}
 
@@ -176,57 +176,57 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 		return t == null ? new LongArrayTag().getEmptyValue() : t.getValue();
 	}
 
-	public Tag put(String key, Tag tag) {
+	public Tag<?> put(String key, Tag<?> tag) {
 		return getValue().put(checkNull(key), checkNull(tag));
 	}
 
-	public Tag putBoolean(String key, boolean value) {
+	public Tag<?> putBoolean(String key, boolean value) {
 		return put(key, new ByteTag(value));
 	}
 
-	public Tag putByte(String key, byte value) {
+	public Tag<?> putByte(String key, byte value) {
 		return put(key, new ByteTag(value));
 	}
 
-	public Tag putShort(String key, short value) {
+	public Tag<?> putShort(String key, short value) {
 		return put(key, new ShortTag(value));
 	}
 
-	public Tag putInt(String key, int value) {
+	public Tag<?> putInt(String key, int value) {
 		return put(key, new IntTag(value));
 	}
 
-	public Tag putLong(String key, long value) {
+	public Tag<?> putLong(String key, long value) {
 		return put(key, new LongTag(value));
 	}
 
-	public Tag putFloat(String key, float value) {
+	public Tag<?> putFloat(String key, float value) {
 		return put(key, new FloatTag(value));
 	}
 
-	public Tag putDouble(String key, double value) {
+	public Tag<?> putDouble(String key, double value) {
 		return put(key, new DoubleTag(value));
 	}
 
-	public Tag putString(String key, String value) {
+	public Tag<?> putString(String key, String value) {
 		return put(key, new StringTag(checkNull(value)));
 	}
 
-	public Tag putByteArray(String key, byte[] value) {
+	public Tag<?> putByteArray(String key, byte[] value) {
 		return put(key, new ByteArrayTag(checkNull(value)));
 	}
 
-	public Tag putIntArray(String key, int[] value) {
+	public Tag<?> putIntArray(String key, int[] value) {
 		return put(key, new IntArrayTag(checkNull(value)));
 	}
 
-	public Tag putLongArray(String key, long[] value) {
+	public Tag<?> putLongArray(String key, long[] value) {
 		return put(key, new LongArrayTag(checkNull(value)));
 	}
 
 	@Override
 	public void serializeValue(DataOutputStream dos, int depth) throws IOException {
-		for (Map.Entry<String, Tag> e : getValue().entrySet()) {
+		for (Map.Entry<String, Tag<?>> e : getValue().entrySet()) {
 			dos.writeByte(e.getValue().getID());
 			dos.writeUTF(e.getKey());
 			e.getValue().serializeValue(dos, incrementDepth(depth));
@@ -237,7 +237,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 	@Override
 	public void deserializeValue(DataInputStream dis, int depth) throws IOException {
 		for (int id = dis.readByte() & 0xFF; id != 0; id = dis.readByte() & 0xFF) {
-			Tag tag = TagFactory.fromID(id);
+			Tag<?> tag = TagFactory.fromID(id);
 			String name = dis.readUTF();
 			tag.deserializeValue(dis, incrementDepth(depth));
 			put(name, tag);
@@ -248,7 +248,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 	public String valueToString(int depth) {
 		StringBuilder sb = new StringBuilder("{");
 		boolean first = true;
-		for (Map.Entry<String, Tag> e : getValue().entrySet()) {
+		for (Map.Entry<String, Tag<?>> e : getValue().entrySet()) {
 			sb.append(first ? "" : ",")
 					.append(escapeString(e.getKey(), false)).append(":")
 					.append(e.getValue().toString(incrementDepth(depth)));
@@ -262,7 +262,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 	public String valueToTagString(int depth) {
 		StringBuilder sb = new StringBuilder("{");
 		boolean first = true;
-		for (Map.Entry<String, Tag> e : getValue().entrySet()) {
+		for (Map.Entry<String, Tag<?>> e : getValue().entrySet()) {
 			sb.append(first ? "" : ",")
 					.append(escapeString(e.getKey(), true)).append(":")
 					.append(e.getValue().valueToTagString(incrementDepth(depth)));
@@ -280,8 +280,8 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 		if (!super.equals(other) || size() != ((CompoundTag) other).size()) {
 			return false;
 		}
-		for (Map.Entry<String, Tag> e : getValue().entrySet()) {
-			Tag v;
+		for (Map.Entry<String, Tag<?>> e : getValue().entrySet()) {
+			Tag<?> v;
 			if ((v = ((CompoundTag) other).get(e.getKey())) == null || !e.getValue().equals(v)) {
 				return false;
 			}
@@ -295,7 +295,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 	}
 
 	@Override
-	public int compareTo(Tag<Map<String, Tag>> o) {
+	public int compareTo(Tag<Map<String, Tag<?>>> o) {
 		if (!(o instanceof CompoundTag)) {
 			return 0;
 		}
@@ -305,7 +305,7 @@ public class CompoundTag extends Tag<Map<String, Tag>> implements Iterable<Map.E
 	@Override
 	public CompoundTag clone() {
 		CompoundTag copy = new CompoundTag();
-		for (Map.Entry<String, Tag> e : getValue().entrySet()) {
+		for (Map.Entry<String, Tag<?>> e : getValue().entrySet()) {
 			copy.put(e.getKey(), e.getValue().clone());
 		}
 		return copy;

--- a/src/main/java/net/querz/nbt/DoubleTag.java
+++ b/src/main/java/net/querz/nbt/DoubleTag.java
@@ -13,11 +13,6 @@ public class DoubleTag extends NumberTag<Double> {
 	}
 
 	@Override
-	public byte getID() {
-		return 6;
-	}
-
-	@Override
 	protected Double getEmptyValue() {
 		return 0.0d;
 	}

--- a/src/main/java/net/querz/nbt/EndTag.java
+++ b/src/main/java/net/querz/nbt/EndTag.java
@@ -10,11 +10,6 @@ public final class EndTag extends Tag<Void> {
 	private EndTag() {}
 
 	@Override
-	public byte getID() {
-		return 0;
-	}
-
-	@Override
 	protected Void getEmptyValue() {
 		return null;
 	}

--- a/src/main/java/net/querz/nbt/FloatTag.java
+++ b/src/main/java/net/querz/nbt/FloatTag.java
@@ -13,11 +13,6 @@ public class FloatTag extends NumberTag<Float> {
 	}
 
 	@Override
-	public byte getID() {
-		return 5;
-	}
-
-	@Override
 	protected Float getEmptyValue() {
 		return 0.0f;
 	}

--- a/src/main/java/net/querz/nbt/IntArrayTag.java
+++ b/src/main/java/net/querz/nbt/IntArrayTag.java
@@ -14,11 +14,6 @@ public class IntArrayTag extends ArrayTag<int[]> {
 	}
 
 	@Override
-	public byte getID() {
-		return 11;
-	}
-
-	@Override
 	protected int[] getEmptyValue() {
 		return new int[0];
 	}

--- a/src/main/java/net/querz/nbt/IntArrayTag.java
+++ b/src/main/java/net/querz/nbt/IntArrayTag.java
@@ -7,7 +7,9 @@ import java.util.Arrays;
 
 public class IntArrayTag extends ArrayTag<int[]> {
 
-	public IntArrayTag() {}
+	public IntArrayTag() {
+		super(new int[0]);
+	}
 
 	public IntArrayTag(int[] value) {
 		super(value);
@@ -37,7 +39,7 @@ public class IntArrayTag extends ArrayTag<int[]> {
 
 	@Override
 	public String valueToTagString(int depth) {
-		return arrayToString(getValue(), "I", "");
+		return arrayToString("I", "");
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/IntTag.java
+++ b/src/main/java/net/querz/nbt/IntTag.java
@@ -13,11 +13,6 @@ public class IntTag extends NumberTag<Integer> {
 	}
 
 	@Override
-	public byte getID() {
-		return 3;
-	}
-
-	@Override
 	protected Integer getEmptyValue() {
 		return 0;
 	}

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -306,7 +306,7 @@ public class ListTag<T extends Tag> extends Tag<List<T>> implements Iterable<T> 
 
 	@SuppressWarnings("unchecked")
 	private void addUnchecked(Tag tag) {
-		if (typeID != 0 && tag.getID() != typeID) {
+		if (typeClass != EndTag.class && typeClass != tag.getClass() || typeID != 0 && tag.getID() != typeID) {
 			throw new IllegalArgumentException(String.format(
 					"cannot add %s to ListTag<%s>",
 					tag.getClass().getSimpleName(), typeClass.getSimpleName()));

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -13,11 +13,10 @@ import java.util.function.Consumer;
 
 /**
  * ListTag represents a typed List in the nbt structure.
- * An empty ListTag is of type {@code EndTag}.
- * Having this in mind, ListTag will always act consistent with serialization
- * regarding its type. Therefore  will return {@code 0}
- * and {@link ListTag#getTypeClass()} will return {@code EndTag.class}
- * when called on an empty ListTag.
+ * An empty {@link ListTag} created using {@link ListTag#createUnchecked()} will be of unknown type
+ * and returns an {@link EndTag}{@code .class} in {@link ListTag#getTypeClass()}.
+ * The type of an empty untyped {@link ListTag} can be set by using any of the {@code add()}
+ * methods or any of the {@code as...List()} methods.
  * */
 public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<T> {
 
@@ -48,11 +47,6 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 			throw new IllegalArgumentException("cannot create ListTag with EndTag elements");
 		}
 		this.typeClass = checkNull(typeClass);
-	}
-
-	@Override
-	public byte getID() {
-		return 9;
 	}
 
 	public Class<?> getTypeClass() {
@@ -274,7 +268,7 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 
 	@Override
 	public String valueToString(int depth) {
-		StringBuilder sb = new StringBuilder("{\"type\":\"").append(typeClass.getSimpleName()).append("\",\"list\":[");
+		StringBuilder sb = new StringBuilder("{\"type\":\"").append(getTypeClass().getSimpleName()).append("\",\"list\":[");
 		for (int i = 0; i < size(); i++) {
 			sb.append(i > 0 ? "," : "").append(get(i).valueToString(incrementDepth(depth)));
 		}
@@ -297,7 +291,7 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 		if (this == other) {
 			return true;
 		}
-		if (!super.equals(other) || size() != ((ListTag<?>) other).size() || typeClass != ((ListTag<?>) other).getTypeClass()) {
+		if (!super.equals(other) || size() != ((ListTag<?>) other).size() || getTypeClass() != ((ListTag<?>) other).getTypeClass()) {
 			return false;
 		}
 		for (int i = 0; i < size(); i++) {

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -10,6 +10,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 
+/**
+ * ListTag represents a typed List in the nbt structure.
+ * An empty ListTag is of type {@code EndTag}.
+ * Having this in mind, ListTag will always act consistent with serialization
+ * regarding its type. Therefore {@link ListTag#getTypeID()} will return {@code 0}
+ * and {@link ListTag#getTypeClass()} will return {@code EndTag.class}
+ * when called on an empty ListTag.
+ * */
 public class ListTag<T extends Tag> extends Tag<List<T>> implements Iterable<T> {
 
 	private byte typeID = 0;

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -17,7 +17,7 @@ public class ListTag<T extends Tag> extends Tag<List<T>> implements Iterable<T> 
 
 	protected ListTag() {}
 
-	public ListTag(Class<? extends Tag> typeClass) {
+	public ListTag(Class<T> typeClass) {
 		this.typeClass = typeClass;
 	}
 
@@ -207,10 +207,8 @@ public class ListTag<T extends Tag> extends Tag<List<T>> implements Iterable<T> 
 		return asTypedList(LongArrayTag.class);
 	}
 
-	@SuppressWarnings("unchecked")
-	public ListTag<ListTag<?>> asListTagList() {
-		checkTypeClass(ListTag.class);
-		return (ListTag<ListTag<?>>) this;
+	public ListTag<ListTag> asListTagList() {
+		return asTypedList(ListTag.class);
 	}
 
 	public ListTag<CompoundTag> asCompoundTagList() {

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -276,7 +276,7 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 	public String valueToString(int depth) {
 		StringBuilder sb = new StringBuilder("{\"type\":\"").append(typeClass.getSimpleName()).append("\",\"list\":[");
 		for (int i = 0; i < size(); i++) {
-			sb.append(i > 0 ? "," : "").append(get(i).toString(incrementDepth(depth)));
+			sb.append(i > 0 ? "," : "").append(get(i).valueToString(incrementDepth(depth)));
 		}
 		sb.append("]}");
 		return sb.toString();

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -325,9 +325,9 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 	@Override
 	public ListTag<T> clone() {
 		ListTag<T> copy = new ListTag<>();
-		// At least set typeID to get some type safety if list is empty
+		// assure type safety for clone
 		copy.typeID = typeID;
-		
+		copy.typeClass = typeClass;
 		for (T t : getValue()) {
 			copy.add((T) t.clone());
 		}

--- a/src/main/java/net/querz/nbt/LongArrayTag.java
+++ b/src/main/java/net/querz/nbt/LongArrayTag.java
@@ -14,11 +14,6 @@ public class LongArrayTag extends ArrayTag<long[]> {
 	}
 
 	@Override
-	public byte getID() {
-		return 12;
-	}
-
-	@Override
 	protected long[] getEmptyValue() {
 		return new long[0];
 	}

--- a/src/main/java/net/querz/nbt/LongArrayTag.java
+++ b/src/main/java/net/querz/nbt/LongArrayTag.java
@@ -7,7 +7,9 @@ import java.util.Arrays;
 
 public class LongArrayTag extends ArrayTag<long[]> {
 
-	public LongArrayTag() {}
+	public LongArrayTag() {
+		super(new long[0]);
+	}
 
 	public LongArrayTag(long[] value) {
 		super(value);
@@ -37,7 +39,7 @@ public class LongArrayTag extends ArrayTag<long[]> {
 
 	@Override
 	public String valueToTagString(int depth) {
-		return arrayToString(getValue(), "L", "l");
+		return arrayToString("L", "l");
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/LongTag.java
+++ b/src/main/java/net/querz/nbt/LongTag.java
@@ -13,11 +13,6 @@ public class LongTag extends NumberTag<Long> {
 	}
 
 	@Override
-	public byte getID() {
-		return 4;
-	}
-
-	@Override
 	protected Long getEmptyValue() {
 		return 0L;
 	}

--- a/src/main/java/net/querz/nbt/NBTUtil.java
+++ b/src/main/java/net/querz/nbt/NBTUtil.java
@@ -22,6 +22,11 @@ public final class NBTUtil {
 	/**
 	 * Calls {@link NBTUtil#writeTag(Tag, String, File, boolean)} with an empty name and GZIP compression.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
+	 * @param tag The tag to be written to the file.
+	 * @param file The file to write {@code tag} into.
+	 * @throws IOException If something during the serialization goes wrong.
+	 * @exception NullPointerException If {@code tag}, {@code name} or {@code file} is {@code null}.
+	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 */
 	public static void writeTag(Tag<?> tag, String file) throws IOException {
 		writeTag(tag, "", new File(file), true);
@@ -30,6 +35,11 @@ public final class NBTUtil {
 	/**
 	 * Calls {@link NBTUtil#writeTag(Tag, String, File, boolean)} with an empty name and GZIP compression.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
+	 * @param tag The tag to be written to the file.
+	 * @param file The file to write {@code tag} into.
+	 * @throws IOException If something during the serialization goes wrong.
+	 * @exception NullPointerException If {@code tag}, {@code name} or {@code file} is {@code null}.
+	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 */
 	public static void writeTag(Tag<?> tag, File file) throws IOException {
 		writeTag(tag, "", file, true);
@@ -38,6 +48,12 @@ public final class NBTUtil {
 	/**
 	 * Calls {@link NBTUtil#writeTag(Tag, String, File, boolean)} with an empty name.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
+	 * @param tag The tag to be written to the file.
+	 * @param file The file to write {@code tag} into.
+	 * @param compressed {@code true} if the file should be GZIP compressed, {@code false} if not.
+	 * @throws IOException If something during the serialization goes wrong.
+	 * @exception NullPointerException If {@code tag}, {@code name} or {@code file} is {@code null}.
+	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 */
 	public static void writeTag(Tag<?> tag, String file, boolean compressed) throws IOException {
 		writeTag(tag, "", new File(file), compressed);
@@ -46,6 +62,12 @@ public final class NBTUtil {
 	/**
 	 * Calls {@link NBTUtil#writeTag(Tag, String, File, boolean)} with an empty name.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
+	 * @param tag The tag to be written to the file.
+	 * @param file The file to write {@code tag} into.
+	 * @param compressed {@code true} if the file should be GZIP compressed, {@code false} if not.
+	 * @throws IOException If something during the serialization goes wrong.
+	 * @exception NullPointerException If {@code tag}, {@code name} or {@code file} is {@code null}.
+	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 * */
 	public static void writeTag(Tag<?> tag, File file, boolean compressed) throws IOException {
 		writeTag(tag, "", file, compressed);
@@ -53,6 +75,12 @@ public final class NBTUtil {
 
 	/**
 	 * @see NBTUtil#writeTag(Tag, String, File)
+	 * @param tag The tag to be written to the file.
+	 * @param name The name of the root tag.
+	 * @param file The file to write {@code tag} into.
+	 * @throws IOException If something during the serialization goes wrong.
+	 * @exception NullPointerException If {@code tag}, {@code name} or {@code file} is {@code null}.
+	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 */
 	public static void writeTag(Tag<?> tag, String name, String file) throws IOException {
 		writeTag(tag, name, new File(file), true);
@@ -61,6 +89,12 @@ public final class NBTUtil {
 	/**
 	 * Calls {@link NBTUtil#writeTag(Tag, String, String, boolean)} with GZIP compression.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
+	 * @param tag The tag to be written to the file.
+	 * @param name The name of the root tag.
+	 * @param file The file to write {@code tag} into.
+	 * @throws IOException If something during the serialization goes wrong.
+	 * @exception NullPointerException If {@code tag}, {@code name} or {@code file} is {@code null}.
+	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 */
 	public static void writeTag(Tag<?> tag, String name, File file) throws IOException {
 		writeTag(tag, name, file, true);
@@ -68,6 +102,13 @@ public final class NBTUtil {
 
 	/**
 	 * @see NBTUtil#writeTag(Tag, String, String, boolean)
+	 * @param tag The tag to be written to the file.
+	 * @param name The name of the root tag.
+	 * @param file The file to write {@code tag} into.
+	 * @param compressed {@code true} if the file should be GZIP compressed, {@code false} if not.
+	 * @throws IOException If something during the serialization goes wrong.
+	 * @exception NullPointerException If {@code tag}, {@code name} or {@code file} is {@code null}.
+	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 */
 	public static void writeTag(Tag<?> tag, String name, String file, boolean compressed) throws IOException {
 		writeTag(tag, name, new File(file), compressed);
@@ -95,6 +136,9 @@ public final class NBTUtil {
 
 	/**
 	 * @see NBTUtil#readTag(File)
+	 * @param file The file to read a Tag from.
+	 * @return The tag read from the file.
+	 * @throws IOException If something during deserialization goes wrong.
 	 * */
 	public static Tag<?> readTag(String file) throws IOException {
 		return readTag(new File(file));

--- a/src/main/java/net/querz/nbt/NBTUtil.java
+++ b/src/main/java/net/querz/nbt/NBTUtil.java
@@ -23,7 +23,7 @@ public final class NBTUtil {
 	 * Calls {@link NBTUtil#writeTag(Tag, String, File, boolean)} with an empty name and GZIP compression.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
 	 */
-	public static void writeTag(Tag tag, String file) throws IOException {
+	public static void writeTag(Tag<?> tag, String file) throws IOException {
 		writeTag(tag, "", new File(file), true);
 	}
 
@@ -31,7 +31,7 @@ public final class NBTUtil {
 	 * Calls {@link NBTUtil#writeTag(Tag, String, File, boolean)} with an empty name and GZIP compression.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
 	 */
-	public static void writeTag(Tag tag, File file) throws IOException {
+	public static void writeTag(Tag<?> tag, File file) throws IOException {
 		writeTag(tag, "", file, true);
 	}
 
@@ -39,7 +39,7 @@ public final class NBTUtil {
 	 * Calls {@link NBTUtil#writeTag(Tag, String, File, boolean)} with an empty name.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
 	 */
-	public static void writeTag(Tag tag, String file, boolean compressed) throws IOException {
+	public static void writeTag(Tag<?> tag, String file, boolean compressed) throws IOException {
 		writeTag(tag, "", new File(file), compressed);
 	}
 
@@ -47,14 +47,14 @@ public final class NBTUtil {
 	 * Calls {@link NBTUtil#writeTag(Tag, String, File, boolean)} with an empty name.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
 	 * */
-	public static void writeTag(Tag tag, File file, boolean compressed) throws IOException {
+	public static void writeTag(Tag<?> tag, File file, boolean compressed) throws IOException {
 		writeTag(tag, "", file, compressed);
 	}
 
 	/**
 	 * @see NBTUtil#writeTag(Tag, String, File)
 	 */
-	public static void writeTag(Tag tag, String name, String file) throws IOException {
+	public static void writeTag(Tag<?> tag, String name, String file) throws IOException {
 		writeTag(tag, name, new File(file), true);
 	}
 
@@ -62,14 +62,14 @@ public final class NBTUtil {
 	 * Calls {@link NBTUtil#writeTag(Tag, String, String, boolean)} with GZIP compression.
 	 * @see NBTUtil#writeTag(Tag, String, File, boolean)
 	 */
-	public static void writeTag(Tag tag, String name, File file) throws IOException {
+	public static void writeTag(Tag<?> tag, String name, File file) throws IOException {
 		writeTag(tag, name, file, true);
 	}
 
 	/**
 	 * @see NBTUtil#writeTag(Tag, String, String, boolean)
 	 */
-	public static void writeTag(Tag tag, String name, String file, boolean compressed) throws IOException {
+	public static void writeTag(Tag<?> tag, String name, String file, boolean compressed) throws IOException {
 		writeTag(tag, name, new File(file), compressed);
 	}
 
@@ -84,7 +84,7 @@ public final class NBTUtil {
 	 * @exception NullPointerException If {@code tag}, {@code name} or {@code file} is {@code null}.
 	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 */
-	public static void writeTag(Tag tag, String name, File file, boolean compressed) throws IOException {
+	public static void writeTag(Tag<?> tag, String name, File file, boolean compressed) throws IOException {
 		try (
 				DataOutputStream dos = new DataOutputStream(
 						compressed ? new GZIPOutputStream(new FileOutputStream(file)) : new FileOutputStream(file))
@@ -96,7 +96,7 @@ public final class NBTUtil {
 	/**
 	 * @see NBTUtil#readTag(File)
 	 * */
-	public static Tag readTag(String file) throws IOException {
+	public static Tag<?> readTag(String file) throws IOException {
 		return readTag(new File(file));
 	}
 
@@ -109,7 +109,7 @@ public final class NBTUtil {
 	 * @throws NullPointerException If {@code file} is {@code null}.
 	 * @exception MaxDepthReachedException If the NBT structure exceeds {@link Tag#MAX_DEPTH}.
 	 * */
-	public static Tag readTag(File file) throws IOException {
+	public static Tag<?> readTag(File file) throws IOException {
 		try (DataInputStream dis = new DataInputStream(applyDecompression(new FileInputStream(file)))) {
 			return Tag.deserialize(dis, 0);
 		}

--- a/src/main/java/net/querz/nbt/ShortTag.java
+++ b/src/main/java/net/querz/nbt/ShortTag.java
@@ -13,11 +13,6 @@ public class ShortTag extends NumberTag<Short> {
 	}
 
 	@Override
-	public byte getID() {
-		return 2;
-	}
-
-	@Override
 	protected Short getEmptyValue() {
 		return 0;
 	}

--- a/src/main/java/net/querz/nbt/StringTag.java
+++ b/src/main/java/net/querz/nbt/StringTag.java
@@ -13,11 +13,6 @@ public class StringTag extends Tag<String> {
 	}
 
 	@Override
-	public byte getID() {
-		return 8;
-	}
-
-	@Override
 	protected String getEmptyValue() {
 		return "";
 	}

--- a/src/main/java/net/querz/nbt/Tag.java
+++ b/src/main/java/net/querz/nbt/Tag.java
@@ -48,7 +48,9 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 	/**
 	 * @return This Tag's ID, usually used for serialization and deserialization.
 	 * */
-	public abstract byte getID();
+	public byte getID() {
+		return TagFactory.idFromClass(getClass());
+	}
 
 	/**
 	 * @return A default value for this Tag.

--- a/src/main/java/net/querz/nbt/Tag.java
+++ b/src/main/java/net/querz/nbt/Tag.java
@@ -75,6 +75,9 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 	/**
 	 * Calls {@link Tag#serialize(DataOutputStream, String, int)} with an empty name.
 	 * @see Tag#serialize(DataOutputStream, String, int)
+	 * @param dos The DataOutputStream to write to
+	 * @param depth The current depth of the structure
+	 * @throws IOException If something went wrong during serialization
 	 * */
 	public final void serialize(DataOutputStream dos, int depth) throws IOException {
 		serialize(dos, "", depth);
@@ -82,7 +85,7 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 
 	/**
 	 * Serializes this Tag starting at the gives depth.
-	 * @param dos The DataOutputStream to serialize into.
+	 * @param dos The DataOutputStream to write to.
 	 * @param name The name of this Tag, if this is the root Tag.
 	 * @param depth The current depth of the structure.
 	 * @throws IOException If something went wrong during serialization.
@@ -105,6 +108,7 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 	 * @throws IOException If something went wrong during deserialization.
 	 * @exception NullPointerException If {@code dis} is {@code null}.
 	 * @exception MaxDepthReachedException If the structure depth exceeds {@link Tag#MAX_DEPTH}.
+	 * @return The deserialized NBT structure.
 	 * */
 	public static Tag<?> deserialize(DataInputStream dis, int depth) throws IOException {
 		int id = dis.readByte() & 0xFF;
@@ -165,6 +169,7 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 	/**
 	 * Calls {@link Tag#toTagString(int)} with an initial depth of {@code 0}.
 	 * @see Tag#toTagString(int)
+	 * @return The JSON-like string representation of this Tag.
 	 * */
 	public String toTagString() {
 		return toTagString(0);
@@ -219,7 +224,8 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 	public abstract Tag<T> clone();
 
 	/**
-	 * A utility method to check if some value is null.
+	 * A utility method to check if some value is {@code null}.
+	 * @param <V> Any type that should be checked for being {@code null}
 	 * @param v The value to check.
 	 * @return {@code v}, if it's not {@code null}.
 	 * @exception NullPointerException If {@code v} is {@code null}.

--- a/src/main/java/net/querz/nbt/Tag.java
+++ b/src/main/java/net/querz/nbt/Tag.java
@@ -104,9 +104,9 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 	 * @exception NullPointerException If {@code dis} is {@code null}.
 	 * @exception MaxDepthReachedException If the structure depth exceeds {@link Tag#MAX_DEPTH}.
 	 * */
-	public static Tag deserialize(DataInputStream dis, int depth) throws IOException {
+	public static Tag<?> deserialize(DataInputStream dis, int depth) throws IOException {
 		int id = dis.readByte() & 0xFF;
-		Tag tag = TagFactory.fromID(id);
+		Tag<?> tag = TagFactory.fromID(id);
 		if (id != 0) {
 			dis.readUTF();
 			tag.deserializeValue(dis, depth);
@@ -214,7 +214,7 @@ public abstract class Tag<T> implements Comparable<Tag<T>>, Cloneable {
 	 * @return A clone of this Tag.
 	 * */
 	@SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
-	public abstract Tag clone();
+	public abstract Tag<T> clone();
 
 	/**
 	 * A utility method to check if some value is null.

--- a/src/main/java/net/querz/nbt/TagFactory.java
+++ b/src/main/java/net/querz/nbt/TagFactory.java
@@ -61,12 +61,12 @@ public final class TagFactory {
 		return mapping.clazz;
 	}
 
-	public static int idFromClass(Class<?> clazz) {
+	public static byte idFromClass(Class<?> clazz) {
 		TagMapping<?> mapping = classMapping.get(clazz);
 		if (mapping == null) {
 			throw new IllegalArgumentException("unknown Tag class " + clazz.getName());
 		}
-		return mapping.id;
+		return (byte) mapping.id;
 	}
 
 	public static <T extends Tag<?>> void registerCustomTag(int id, Supplier<T> factory, Class<T> clazz) {

--- a/src/main/java/net/querz/nbt/TagFactory.java
+++ b/src/main/java/net/querz/nbt/TagFactory.java
@@ -10,7 +10,7 @@ public class TagFactory {
 
 	private TagFactory() {}
 
-	public static Tag fromID(int id) {
+	public static Tag<?> fromID(int id) {
 		switch (id) {
 			case 0:
 				return EndTag.INSTANCE;
@@ -31,7 +31,7 @@ public class TagFactory {
 			case 8:
 				return new StringTag();
 			case 9:
-				return new ListTag();
+				return ListTag.createUnchecked();
 			case 10:
 				return new CompoundTag();
 			case 11:

--- a/src/main/java/net/querz/nbt/TagFactory.java
+++ b/src/main/java/net/querz/nbt/TagFactory.java
@@ -4,66 +4,98 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public class TagFactory {
+public final class TagFactory {
 
-	private static Map<Integer, Supplier<? extends Tag<?>>> customTags = new HashMap<>();
+	private static class TagMapping<T extends Tag<?>> {
+
+		private int id;
+		private Supplier<T> factory;
+		private Class<T> clazz;
+
+		TagMapping(int id, Supplier<T> factory, Class<T> clazz) {
+			this.id = id;
+			this.factory = factory;
+			this.clazz = clazz;
+		}
+	}
+
+	private static Map<Integer, TagMapping<?>> idMapping = new HashMap<>();
+	private static Map<Class<?>, TagMapping<?>> classMapping = new HashMap<>();
+	static {
+		put(0, () -> EndTag.INSTANCE, EndTag.class);
+		put(1, ByteTag::new, ByteTag.class);
+		put(2, ShortTag::new, ShortTag.class);
+		put(3, IntTag::new, IntTag.class);
+		put(4, LongTag::new, LongTag.class);
+		put(5, FloatTag::new, FloatTag.class);
+		put(6, DoubleTag::new, DoubleTag.class);
+		put(7, ByteArrayTag::new, ByteArrayTag.class);
+		put(8, StringTag::new, StringTag.class);
+		put(9, ListTag::createUnchecked, ListTag.class);
+		put(10, CompoundTag::new, CompoundTag.class);
+		put(11, IntArrayTag::new, IntArrayTag.class);
+		put(12, LongArrayTag::new, LongArrayTag.class);
+	}
+
+	private static <T extends Tag<?>> void put(int id, Supplier<T> factory, Class<T> clazz) {
+		TagMapping<T> mapping = new TagMapping<>(id, factory, clazz);
+		idMapping.put(id, mapping);
+		classMapping.put(clazz, mapping);
+	}
 
 	private TagFactory() {}
 
 	public static Tag<?> fromID(int id) {
-		switch (id) {
-			case 0:
-				return EndTag.INSTANCE;
-			case 1:
-				return new ByteTag();
-			case 2:
-				return new ShortTag();
-			case 3:
-				return new IntTag();
-			case 4:
-				return new LongTag();
-			case 5:
-				return new FloatTag();
-			case 6:
-				return new DoubleTag();
-			case 7:
-				return new ByteArrayTag();
-			case 8:
-				return new StringTag();
-			case 9:
-				return ListTag.createUnchecked();
-			case 10:
-				return new CompoundTag();
-			case 11:
-				return new IntArrayTag();
-			case 12:
-				return new LongArrayTag();
-			default:
-				Supplier<? extends Tag<?>> factory = customTags.get(id);
-				if (factory != null) {
-					return factory.get();
-				}
-				throw new IllegalArgumentException("unknown Tag id: " + id);
+		TagMapping<?> mapping = idMapping.get(id);
+		if (mapping == null) {
+			throw new IllegalArgumentException("unknown Tag id " + id);
+		}
+		return mapping.factory.get();
+	}
+
+	public static Class<?> classFromID(int id) {
+		TagMapping<?> mapping = idMapping.get(id);
+		if (mapping == null) {
+			throw new IllegalArgumentException("unknown Tag id " + id);
+		}
+		return mapping.clazz;
+	}
+
+	public static int idFromClass(Class<?> clazz) {
+		TagMapping<?> mapping = classMapping.get(clazz);
+		if (mapping == null) {
+			throw new IllegalArgumentException("unknown Tag class " + clazz.getName());
+		}
+		return mapping.id;
+	}
+
+	public static <T extends Tag<?>> void registerCustomTag(int id, Supplier<T> factory, Class<T> clazz) {
+		checkID(id);
+		if (idMapping.containsKey(id)) {
+			throw new IllegalArgumentException("custom tag already registered");
+		}
+		put(id, factory, clazz);
+	}
+
+	public static void unregisterCustomTag(int id) {
+		idMapping.remove(id);
+		for (TagMapping<?> mapping : classMapping.values()) {
+			if (mapping.id == id) {
+				classMapping.remove(mapping.clazz);
+				return;
+			}
 		}
 	}
 
-	public static void registerCustomTag(int id, Supplier<? extends Tag<?>> factory) {
+	private static void checkID(int id) {
 		if (id < 0) {
 			throw new IllegalArgumentException("id cannot be negative");
 		}
 		if (id <= 12) {
-			throw new IllegalArgumentException("cannot overwrite default tags");
+			throw new IllegalArgumentException("cannot change default tags");
 		}
 		if (id > Byte.MAX_VALUE) {
 			throw new IllegalArgumentException("id out of bounds: " + id);
 		}
-		if (customTags.containsKey(id)) {
-			throw new IllegalArgumentException("custom tag already registered");
-		}
-		customTags.put(id, factory);
-	}
-
-	public static void unregisterCustomTag(int id) {
-		customTags.remove(id);
 	}
 }

--- a/src/main/java/net/querz/nbt/custom/CharTag.java
+++ b/src/main/java/net/querz/nbt/custom/CharTag.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 public class CharTag extends Tag<Character> {
 
 	public static void register() {
-		TagFactory.registerCustomTag(110, CharTag::new);
+		TagFactory.registerCustomTag(110, CharTag::new, CharTag.class);
 	}
 
 	public CharTag() {}

--- a/src/main/java/net/querz/nbt/custom/CharTag.java
+++ b/src/main/java/net/querz/nbt/custom/CharTag.java
@@ -19,11 +19,6 @@ public class CharTag extends Tag<Character> {
 	}
 
 	@Override
-	public byte getID() {
-		return 110;
-	}
-
-	@Override
 	protected Character getEmptyValue() {
 		return 0;
 	}

--- a/src/main/java/net/querz/nbt/custom/ObjectTag.java
+++ b/src/main/java/net/querz/nbt/custom/ObjectTag.java
@@ -19,11 +19,6 @@ public class ObjectTag<T extends Serializable> extends Tag<T> {
 	}
 
 	@Override
-	public byte getID() {
-		return 90;
-	}
-
-	@Override
 	protected T getEmptyValue() {
 		return null;
 	}

--- a/src/main/java/net/querz/nbt/custom/ObjectTag.java
+++ b/src/main/java/net/querz/nbt/custom/ObjectTag.java
@@ -9,7 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 public class ObjectTag<T extends Serializable> extends Tag<T> {
 
 	public static void register() {
-		TagFactory.registerCustomTag(90, ObjectTag::new);
+		TagFactory.registerCustomTag(90, ObjectTag::new, ObjectTag.class);
 	}
 
 	public ObjectTag() {}

--- a/src/main/java/net/querz/nbt/custom/ShortArrayTag.java
+++ b/src/main/java/net/querz/nbt/custom/ShortArrayTag.java
@@ -20,11 +20,6 @@ public class ShortArrayTag extends ArrayTag<short[]> {
 	}
 
 	@Override
-	public byte getID() {
-		return 100;
-	}
-
-	@Override
 	protected short[] getEmptyValue() {
 		return new short[0];
 	}

--- a/src/main/java/net/querz/nbt/custom/ShortArrayTag.java
+++ b/src/main/java/net/querz/nbt/custom/ShortArrayTag.java
@@ -13,7 +13,9 @@ public class ShortArrayTag extends ArrayTag<short[]> {
 		TagFactory.registerCustomTag(100, ShortArrayTag::new, ShortArrayTag.class);
 	}
 
-	public ShortArrayTag() {}
+	public ShortArrayTag() {
+		super(new short[0]);
+	}
 
 	public ShortArrayTag(short[] value) {
 		super(value);
@@ -43,7 +45,7 @@ public class ShortArrayTag extends ArrayTag<short[]> {
 
 	@Override
 	public String valueToTagString(int depth) {
-		return arrayToString(getValue(), "S", "s");
+		return arrayToString("S", "s");
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/custom/ShortArrayTag.java
+++ b/src/main/java/net/querz/nbt/custom/ShortArrayTag.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 public class ShortArrayTag extends ArrayTag<short[]> {
 
 	public static void register() {
-		TagFactory.registerCustomTag(100, ShortArrayTag::new);
+		TagFactory.registerCustomTag(100, ShortArrayTag::new, ShortArrayTag.class);
 	}
 
 	public ShortArrayTag() {}

--- a/src/main/java/net/querz/nbt/custom/StructTag.java
+++ b/src/main/java/net/querz/nbt/custom/StructTag.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 public class StructTag extends Tag<List<Tag<?>>> implements Iterable<Tag<?>> {
 
 	public static void register() {
-		TagFactory.registerCustomTag(120, StructTag::new);
+		TagFactory.registerCustomTag(120, StructTag::new, StructTag.class);
 	}
 
 	public StructTag() {}

--- a/src/main/java/net/querz/nbt/custom/StructTag.java
+++ b/src/main/java/net/querz/nbt/custom/StructTag.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
 
-public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
+public class StructTag extends Tag<List<Tag<?>>> implements Iterable<Tag<?>> {
 
 	public static void register() {
 		TagFactory.registerCustomTag(120, StructTag::new);
@@ -34,7 +34,7 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 	}
 
 	@Override
-	protected List<Tag> getEmptyValue() {
+	protected List<Tag<?>> getEmptyValue() {
 		return new ArrayList<>(3);
 	}
 
@@ -42,11 +42,11 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 		return getValue().size();
 	}
 
-	public Tag remove(int index) {
+	public Tag<?> remove(int index) {
 		return getValue().remove(index);
 	}
 
-	public boolean remove(Tag tag) {
+	public boolean remove(Tag<?> tag) {
 		return getValue().remove(tag);
 	}
 
@@ -54,30 +54,30 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 		getValue().clear();
 	}
 
-	public boolean contains(Tag tag) {
+	public boolean contains(Tag<?> tag) {
 		return getValue().contains(tag);
 	}
 
-	public boolean containsAll(Collection<Tag> tags) {
+	public boolean containsAll(Collection<Tag<?>> tags) {
 		return getValue().containsAll(tags);
 	}
 
 	@Override
-	public Iterator<Tag> iterator() {
+	public Iterator<Tag<?>> iterator() {
 		return getValue().iterator();
 	}
 
 	@Override
-	public void forEach(Consumer<? super Tag> action) {
+	public void forEach(Consumer<? super Tag<?>> action) {
 		getValue().forEach(action);
 	}
 
-	public <S extends Tag> S get(int index, Class<S> type) {
-		Tag t = getValue().get(index);
+	public <S extends Tag<?>> S get(int index, Class<S> type) {
+		Tag<?> t = getValue().get(index);
 		return type.cast(t);
 	}
 
-	public Tag get(int index) {
+	public Tag<?> get(int index) {
 		return getValue().get(index);
 	}
 
@@ -130,7 +130,7 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 	}
 
 	public boolean getBoolean(int index) {
-		Tag t = get(index);
+		Tag<?> t = get(index);
 		return t instanceof ByteTag && ((ByteTag) t).asByte() > 0;
 	}
 
@@ -174,15 +174,15 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 		return getLongArrayTag(index).getValue();
 	}
 
-	public Tag set(int index, Tag tag) {
+	public Tag<?> set(int index, Tag<?> tag) {
 		return getValue().set(index, checkNull(tag));
 	}
 
-	public void add(Tag tag) {
+	public void add(Tag<?> tag) {
 		getValue().add(checkNull(tag));
 	}
 
-	public void add(int index, Tag tag) {
+	public void add(int index, Tag<?> tag) {
 		getValue().add(index, checkNull(tag));
 	}
 
@@ -233,7 +233,7 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 	@Override
 	public void serializeValue(DataOutputStream dos, int depth) throws IOException {
 		dos.writeInt(size());
-		for (Tag tag : getValue()) {
+		for (Tag<?> tag : getValue()) {
 			dos.writeByte(tag.getID());
 			tag.serializeValue(dos, incrementDepth(depth));
 		}
@@ -244,7 +244,7 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 		int size = dis.readInt();
 		setValue(new ArrayList<>(size));
 		for (int i = 0; i < size; i++) {
-			Tag tag = TagFactory.fromID(dis.readByte());
+			Tag<?> tag = TagFactory.fromID(dis.readByte());
 			tag.deserializeValue(dis, incrementDepth(depth));
 			add(tag);
 		}
@@ -289,7 +289,7 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 	}
 
 	@Override
-	public int compareTo(Tag<List<Tag>> o) {
+	public int compareTo(Tag<List<Tag<?>>> o) {
 		if (!(o instanceof StructTag)) {
 			return 0;
 		}
@@ -299,7 +299,7 @@ public class StructTag extends Tag<List<Tag>> implements Iterable<Tag> {
 	@Override
 	public StructTag clone() {
 		StructTag copy = new StructTag();
-		for (Tag tag : getValue()) {
+		for (Tag<?> tag : getValue()) {
 			copy.add(tag.clone());
 		}
 		return copy;

--- a/src/main/java/net/querz/nbt/custom/StructTag.java
+++ b/src/main/java/net/querz/nbt/custom/StructTag.java
@@ -29,11 +29,6 @@ public class StructTag extends Tag<List<Tag<?>>> implements Iterable<Tag<?>> {
 	public StructTag() {}
 
 	@Override
-	public byte getID() {
-		return 120;
-	}
-
-	@Override
 	protected List<Tag<?>> getEmptyValue() {
 		return new ArrayList<>(3);
 	}

--- a/src/main/java/net/querz/nbt/mca/Chunk.java
+++ b/src/main/java/net/querz/nbt/mca/Chunk.java
@@ -328,7 +328,7 @@ public class Chunk {
 		if (postProcessing != null) level.put("PostProcessing", postProcessing);
 		level.putString("Status", status);
 		if (structures != null) level.put("Structures", structures);
-		ListTag<CompoundTag> sections = new ListTag<>();
+		ListTag<CompoundTag> sections = new ListTag<>(CompoundTag.class);
 		for (int i = 0; i < this.sections.length; i++) {
 			if (this.sections[i] != null) {
 				sections.add(this.sections[i].updateHandle(i));

--- a/src/main/java/net/querz/nbt/mca/Chunk.java
+++ b/src/main/java/net/querz/nbt/mca/Chunk.java
@@ -31,10 +31,10 @@ public class Chunk {
 	private ListTag<CompoundTag> tileEntities;
 	private ListTag<CompoundTag> tileTicks;
 	private ListTag<CompoundTag> liquidTicks;
-	private ListTag<ListTag> lights;
-	private ListTag<ListTag> liquidsToBeTicked;
-	private ListTag<ListTag> toBeTicked;
-	private ListTag<ListTag> postProcessing;
+	private ListTag<ListTag<?>> lights;
+	private ListTag<ListTag<?>> liquidsToBeTicked;
+	private ListTag<ListTag<?>> toBeTicked;
+	private ListTag<ListTag<?>> postProcessing;
 	private String status;
 	private CompoundTag structures;
 
@@ -97,7 +97,7 @@ public class Chunk {
 			throw new IOException("invalid compression type " + compressionTypeByte);
 		}
 		DataInputStream dis = new DataInputStream(new BufferedInputStream(compressionType.decompress(new FileInputStream(raf.getFD()))));
-		Tag tag = Tag.deserialize(dis, 0);
+		Tag<?> tag = Tag.deserialize(dis, 0);
 		if (tag instanceof CompoundTag) {
 			data = (CompoundTag) tag;
 			initReferences();
@@ -247,35 +247,35 @@ public class Chunk {
 		this.liquidTicks = liquidTicks;
 	}
 
-	public ListTag<ListTag> getLights() {
+	public ListTag<ListTag<?>> getLights() {
 		return lights;
 	}
 
-	public void setLights(ListTag<ListTag> lights) {
+	public void setLights(ListTag<ListTag<?>> lights) {
 		this.lights = lights;
 	}
 
-	public ListTag<ListTag> getLiquidsToBeTicked() {
+	public ListTag<ListTag<?>> getLiquidsToBeTicked() {
 		return liquidsToBeTicked;
 	}
 
-	public void setLiquidsToBeTicked(ListTag<ListTag> liquidsToBeTicked) {
+	public void setLiquidsToBeTicked(ListTag<ListTag<?>> liquidsToBeTicked) {
 		this.liquidsToBeTicked = liquidsToBeTicked;
 	}
 
-	public ListTag<ListTag> getToBeTicked() {
+	public ListTag<ListTag<?>> getToBeTicked() {
 		return toBeTicked;
 	}
 
-	public void setToBeTicked(ListTag<ListTag> toBeTicked) {
+	public void setToBeTicked(ListTag<ListTag<?>> toBeTicked) {
 		this.toBeTicked = toBeTicked;
 	}
 
-	public ListTag<ListTag> getPostProcessing() {
+	public ListTag<ListTag<?>> getPostProcessing() {
 		return postProcessing;
 	}
 
-	public void setPostProcessing(ListTag<ListTag> postProcessing) {
+	public void setPostProcessing(ListTag<ListTag<?>> postProcessing) {
 		this.postProcessing = postProcessing;
 	}
 

--- a/src/main/java/net/querz/nbt/mca/Chunk.java
+++ b/src/main/java/net/querz/nbt/mca/Chunk.java
@@ -31,10 +31,10 @@ public class Chunk {
 	private ListTag<CompoundTag> tileEntities;
 	private ListTag<CompoundTag> tileTicks;
 	private ListTag<CompoundTag> liquidTicks;
-	private ListTag<ListTag<?>> lights;
-	private ListTag<ListTag<?>> liquidsToBeTicked;
-	private ListTag<ListTag<?>> toBeTicked;
-	private ListTag<ListTag<?>> postProcessing;
+	private ListTag<ListTag> lights;
+	private ListTag<ListTag> liquidsToBeTicked;
+	private ListTag<ListTag> toBeTicked;
+	private ListTag<ListTag> postProcessing;
 	private String status;
 	private CompoundTag structures;
 
@@ -247,35 +247,35 @@ public class Chunk {
 		this.liquidTicks = liquidTicks;
 	}
 
-	public ListTag<ListTag<?>> getLights() {
+	public ListTag<ListTag> getLights() {
 		return lights;
 	}
 
-	public void setLights(ListTag<ListTag<?>> lights) {
+	public void setLights(ListTag<ListTag> lights) {
 		this.lights = lights;
 	}
 
-	public ListTag<ListTag<?>> getLiquidsToBeTicked() {
+	public ListTag<ListTag> getLiquidsToBeTicked() {
 		return liquidsToBeTicked;
 	}
 
-	public void setLiquidsToBeTicked(ListTag<ListTag<?>> liquidsToBeTicked) {
+	public void setLiquidsToBeTicked(ListTag<ListTag> liquidsToBeTicked) {
 		this.liquidsToBeTicked = liquidsToBeTicked;
 	}
 
-	public ListTag<ListTag<?>> getToBeTicked() {
+	public ListTag<ListTag> getToBeTicked() {
 		return toBeTicked;
 	}
 
-	public void setToBeTicked(ListTag<ListTag<?>> toBeTicked) {
+	public void setToBeTicked(ListTag<ListTag> toBeTicked) {
 		this.toBeTicked = toBeTicked;
 	}
 
-	public ListTag<ListTag<?>> getPostProcessing() {
+	public ListTag<ListTag> getPostProcessing() {
 		return postProcessing;
 	}
 
-	public void setPostProcessing(ListTag<ListTag<?>> postProcessing) {
+	public void setPostProcessing(ListTag<ListTag> postProcessing) {
 		this.postProcessing = postProcessing;
 	}
 

--- a/src/main/java/net/querz/nbt/mca/MCAFile.java
+++ b/src/main/java/net/querz/nbt/mca/MCAFile.java
@@ -80,6 +80,10 @@ public class MCAFile {
 		int chunkXOffset = MCAUtil.regionToChunk(regionX);
 		int chunkZOffset = MCAUtil.regionToChunk(regionZ);
 
+		if (chunks == null) {
+			return 0;
+		}
+
 		for (int cx = 0; cx < 32; cx++) {
 			for (int cz = 0; cz < 32; cz++) {
 				int index = getChunkIndex(cx, cz);
@@ -104,7 +108,7 @@ public class MCAFile {
 				raf.writeByte(globalOffset & 0xFF);
 				raf.writeByte(sectors);
 
-				//write timestamp to tmp file
+				// write timestamp
 				raf.seek(index * 4 + 4096);
 				raf.writeInt(changeLastUpdate ? timestamp : chunk.getLastMCAUpdate());
 
@@ -112,7 +116,7 @@ public class MCAFile {
 			}
 		}
 
-		//padding
+		// padding
 		if (lastWritten % 4096 != 0) {
 			raf.seek(globalOffset * 4096 - 1);
 			raf.write(0);

--- a/src/main/java/net/querz/nbt/mca/MCAFile.java
+++ b/src/main/java/net/querz/nbt/mca/MCAFile.java
@@ -55,6 +55,9 @@ public class MCAFile {
 	/**
 	 * Calls {@link MCAFile#serialize(RandomAccessFile, boolean)} without updating any timestamps.
 	 * @see MCAFile#serialize(RandomAccessFile, boolean)
+	 * @param raf The {@code RandomAccessFile} to write to.
+	 * @return The amount of chunks written to the file.
+	 * @throws IOException If something went wrong during serialization.
 	 * */
 	public int serialize(RandomAccessFile raf) throws IOException {
 		return serialize(raf, false);
@@ -66,8 +69,8 @@ public class MCAFile {
 	 * @param raf The {@code RandomAccessFile} to write to.
 	 * @param changeLastUpdate Whether it should update all timestamps that show
 	 *                         when this file was last updated.
-	 * @throws IOException If something went wrong during serialization.
 	 * @return The amount of chunks written to the file.
+	 * @throws IOException If something went wrong during serialization.
 	 * */
 	public int serialize(RandomAccessFile raf, boolean changeLastUpdate) throws IOException {
 		int globalOffset = 2;

--- a/src/main/java/net/querz/nbt/mca/MCAUtil.java
+++ b/src/main/java/net/querz/nbt/mca/MCAUtil.java
@@ -18,6 +18,9 @@ public final class MCAUtil {
 
 	/**
 	 * @see MCAUtil#readMCAFile(File)
+	 * @param file The file to read the data from.
+	 * @return An in-memory representation of the MCA file with decompressed chunk data.
+	 * @throws IOException if something during deserialization goes wrong.
 	 * */
 	public static MCAFile readMCAFile(String file) throws IOException {
 		return readMCAFile(new File(file));
@@ -40,6 +43,10 @@ public final class MCAUtil {
 	/**
 	 * Calls {@link MCAUtil#writeMCAFile(MCAFile, File, boolean)} without changing the timestamps.
 	 * @see MCAUtil#writeMCAFile(MCAFile, File, boolean)
+	 * @param file The file to write to.
+	 * @param mcaFile The data of the MCA file to write.
+	 * @return The amount of chunks written to the file.
+	 * @throws IOException If something goes wrong during serialization.
 	 * */
 	public static int writeMCAFile(MCAFile mcaFile, String file) throws IOException {
 		return writeMCAFile(mcaFile, new File(file), false);
@@ -48,6 +55,10 @@ public final class MCAUtil {
 	/**
 	 * Calls {@link MCAUtil#writeMCAFile(MCAFile, File, boolean)} without changing the timestamps.
 	 * @see MCAUtil#writeMCAFile(MCAFile, File, boolean)
+	 * @param file The file to write to.
+	 * @param mcaFile The data of the MCA file to write.
+	 * @return The amount of chunks written to the file.
+	 * @throws IOException If something goes wrong during serialization.
 	 * */
 	public static int writeMCAFile(MCAFile mcaFile, File file) throws IOException {
 		return writeMCAFile(mcaFile, file, false);
@@ -55,6 +66,11 @@ public final class MCAUtil {
 
 	/**
 	 * @see MCAUtil#writeMCAFile(MCAFile, File, boolean)
+	 * @param file The file to write to.
+	 * @param mcaFile The data of the MCA file to write.
+	 * @param changeLastUpdate Whether to adjust the timestamps of when the file was saved.
+	 * @return The amount of chunks written to the file.
+	 * @throws IOException If something goes wrong during serialization.
 	 * */
 	public static int writeMCAFile(MCAFile mcaFile, String file, boolean changeLastUpdate) throws IOException {
 		return writeMCAFile(mcaFile, new File(file), changeLastUpdate);
@@ -90,6 +106,9 @@ public final class MCAUtil {
 	/**
 	 * Turns the chunks coordinates into region coordinates and calls
 	 * {@link MCAUtil#createNameFromRegionLocation(int, int)}
+	 * @param chunkX The x-value of the location of the chunk.
+	 * @param chunkZ The z-value of the location of the chunk.
+	 * @return A mca filename in the format "r.{regionX}.{regionZ}.mca"
 	 * */
 	public static String createNameFromChunkLocation(int chunkX, int chunkZ) {
 		return createNameFromRegionLocation( chunkToRegion(chunkX), chunkToRegion(chunkZ));
@@ -98,6 +117,9 @@ public final class MCAUtil {
 	/**
 	 * Turns the block coordinates into region coordinates and calls
 	 * {@link MCAUtil#createNameFromRegionLocation(int, int)}
+	 * @param blockX The x-value of the location of the block.
+	 * @param blockZ The z-value of the location of the block.
+	 * @return A mca filename in the format "r.{regionX}.{regionZ}.mca"
 	 * */
 	public static String createNameFromBlockLocation(int blockX, int blockZ) {
 		return createNameFromRegionLocation(blockToRegion(blockX), blockToRegion(blockZ));
@@ -105,8 +127,8 @@ public final class MCAUtil {
 
 	/**
 	 * Creates a filename string from provided chunk coordinates.
-	 * @param regionX The x-value of the location of the chunk.
-	 * @param regionZ The z-value of the location of the chunk.
+	 * @param regionX The x-value of the location of the region.
+	 * @param regionZ The z-value of the location of the region.
 	 * @return A mca filename in the format "r.{regionX}.{regionZ}.mca"
 	 * */
 	public static String createNameFromRegionLocation(int regionX, int regionZ) {

--- a/src/main/java/net/querz/nbt/mca/Section.java
+++ b/src/main/java/net/querz/nbt/mca/Section.java
@@ -253,7 +253,7 @@ public class Section {
 	public static Section newSection() {
 		Section s = new Section();
 		s.blockStates = new long[256];
-		s.palette = new ListTag<>();
+		s.palette = new ListTag<>(CompoundTag.class);
 		CompoundTag air = new CompoundTag();
 		air.putString("Name", "minecraft:air");
 		s.palette.add(air);

--- a/src/test/java/net/querz/nbt/ByteArrayTagTest.java
+++ b/src/test/java/net/querz/nbt/ByteArrayTagTest.java
@@ -1,5 +1,7 @@
 package net.querz.nbt;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.util.Arrays;
 
 public class ByteArrayTagTest extends NBTTestCase {
@@ -10,7 +12,6 @@ public class ByteArrayTagTest extends NBTTestCase {
 		assertEquals(7, t.getID());
 		assertEquals("[B;-128b,0b,127b]", t.toTagString());
 		assertEquals("{\"type\":\"" + t.getClass().getSimpleName() + "\",\"value\":[-128,0,127]}", t.toString());
-		assertThrowsRuntimeException(() -> t.arrayToString(null, "", ""), UnsupportedOperationException.class);
 	}
 
 	public void testEquals() {
@@ -47,5 +48,46 @@ public class ByteArrayTagTest extends NBTTestCase {
 		assertTrue(0 < t.compareTo(t4));
 		assertTrue(0 > t4.compareTo(t));
 		assertThrowsRuntimeException(() -> t.compareTo(null), IllegalArgumentException.class);
+	}
+
+	public void testInvalidType() {
+		assertThrowsRuntimeException(NotAnArrayTag::new, UnsupportedOperationException.class);
+		assertThrowsRuntimeException(() -> new NotAnArrayTag("test"), UnsupportedOperationException.class);
+	}
+
+	public class NotAnArrayTag extends ArrayTag<String> {
+
+		public NotAnArrayTag() {
+			super("");
+		}
+
+		public NotAnArrayTag(String value) {
+			super(value);
+		}
+
+		@Override
+		protected String getEmptyValue() {
+			return "";
+		}
+
+		@Override
+		public void serializeValue(DataOutputStream dos, int depth) {
+			throw new UnsupportedOperationException("goddammit, this is a test class, you don't want to save it.");
+		}
+
+		@Override
+		public void deserializeValue(DataInputStream dis, int depth) {
+			throw new UnsupportedOperationException("goddammit, this is a test class, you don't want to load it.");
+		}
+
+		@Override
+		public String valueToTagString(int depth) {
+			return escapeString(getValue(), true);
+		}
+
+		@Override
+		public NotAnArrayTag clone() {
+			return new NotAnArrayTag(getName());
+		}
 	}
 }

--- a/src/test/java/net/querz/nbt/CompoundTagTest.java
+++ b/src/test/java/net/querz/nbt/CompoundTagTest.java
@@ -12,7 +12,7 @@ public class CompoundTagTest extends NBTTestCase {
 		invokeSetValue(ct, new LinkedHashMap<>());
 		ct.put("b", new ByteTag(Byte.MAX_VALUE));
 		ct.put("str", new StringTag("foo"));
-		ct.put("list", new ListTag<>());
+		ct.put("list", new ListTag<>(ByteTag.class));
 		ct.getListTag("list").addByte((byte) 123);
 		return ct;
 	}
@@ -33,7 +33,7 @@ public class CompoundTagTest extends NBTTestCase {
 		CompoundTag ct2 = new CompoundTag();
 		ct2.putByte("b", Byte.MAX_VALUE);
 		ct2.putString("str", "foo");
-		ct2.put("list", new ListTag<>());
+		ct2.put("list", new ListTag<>(ByteTag.class));
 		ct2.getListTag("list").addByte((byte) 123);
 		assertTrue(ct.equals(ct2));
 
@@ -75,7 +75,7 @@ public class CompoundTagTest extends NBTTestCase {
 			t.putIntArray("key_int_array" + i, iArray);
 			t.putLongArray("key_long_array" + i, lArray);
 
-			ListTag<StringTag> l = new ListTag<>();
+			ListTag<StringTag> l = new ListTag<>(StringTag.class);
 			for (int j = 0; j < 256; j++) {
 				l.addString("value" + j);
 			}
@@ -111,7 +111,7 @@ public class CompoundTagTest extends NBTTestCase {
 			t2.putIntArray("key_int_array" + i, iArray);
 			t2.putLongArray("key_long_array" + i, lArray);
 
-			ListTag<StringTag> l = new ListTag<>();
+			ListTag<StringTag> l = new ListTag<>(StringTag.class);
 			for (int j = 0; j < 256; j++) {
 				l.addString("value" + j);
 			}
@@ -238,8 +238,8 @@ public class CompoundTagTest extends NBTTestCase {
 		assertThrowsRuntimeException(() -> cc.getListTag("la"), ClassCastException.class);
 		assertTrue(Arrays.equals(new long[0], cc.getLongArray("lala")));
 
-		cc.put("li", new ListTag<>());
-		assertEquals(new ListTag<>(), cc.getListTag("li"));
+		cc.put("li", new ListTag<>(IntTag.class));
+		assertEquals(new ListTag<>(IntTag.class), cc.getListTag("li"));
 		assertNull(cc.getListTag("lili"));
 		assertThrowsRuntimeException(() -> cc.getCompoundTag("li"), ClassCastException.class);
 
@@ -292,7 +292,7 @@ public class CompoundTagTest extends NBTTestCase {
 	public void testEntrySet() {
 		CompoundTag e = new CompoundTag();
 		e.putInt("int", 123);
-		for (Map.Entry<String, Tag> en : e.entrySet()) {
+		for (Map.Entry<String, Tag<?>> en : e.entrySet()) {
 			assertThrowsRuntimeException(() -> en.setValue(null), NullPointerException.class);
 			assertThrowsNoRuntimeException(() -> en.setValue(new IntTag(321)));
 		}
@@ -308,7 +308,7 @@ public class CompoundTagTest extends NBTTestCase {
 		assertTrue(ct.containsKey("list"));
 		assertFalse(ct.containsKey("invalid"));
 		assertTrue(ct.containsValue(new StringTag("foo")));
-		ListTag<ByteTag> l = new ListTag<>();
+		ListTag<ByteTag> l = new ListTag<>(ByteTag.class);
 		l.addByte((byte) 123);
 		assertTrue(ct.containsValue(l));
 		assertTrue(ct.containsValue(new ByteTag(Byte.MAX_VALUE)));
@@ -318,7 +318,7 @@ public class CompoundTagTest extends NBTTestCase {
 
 	public void testIterator() {
 		CompoundTag ct = createCompoundTag();
-		for (Tag t : ct.values()) {
+		for (Tag<?> t : ct.values()) {
 			assertNotNull(t);
 		}
 		ct.values().remove(new StringTag("foo"));
@@ -333,7 +333,7 @@ public class CompoundTagTest extends NBTTestCase {
 		assertFalse(ct.containsKey("str"));
 		assertThrowsRuntimeException(() -> ct.keySet().add("str"), UnsupportedOperationException.class);
 		ct.putString("str", "foo");
-		for (Map.Entry<String, Tag> e : ct.entrySet()) {
+		for (Map.Entry<String, Tag<?>> e : ct.entrySet()) {
 			assertNotNull(e.getKey());
 			assertNotNull(e.getValue());
 			assertThrowsRuntimeException(() -> e.setValue(null), NullPointerException.class);
@@ -343,7 +343,7 @@ public class CompoundTagTest extends NBTTestCase {
 		}
 		assertTrue(ct.containsKey("str"));
 		assertEquals("bar", ct.getString("str"));
-		for (Map.Entry<String, Tag> e : ct) {
+		for (Map.Entry<String, Tag<?>> e : ct) {
 			assertNotNull(e.getKey());
 			assertNotNull(e.getValue());
 			assertThrowsRuntimeException(() -> e.setValue(null), NullPointerException.class);

--- a/src/test/java/net/querz/nbt/CompoundTagTest.java
+++ b/src/test/java/net/querz/nbt/CompoundTagTest.java
@@ -25,7 +25,7 @@ public class CompoundTagTest extends NBTTestCase {
 				"\"b\":{\"type\":\"ByteTag\",\"value\":127}," +
 				"\"str\":{\"type\":\"StringTag\",\"value\":\"foo\"}," +
 				"\"list\":{\"type\":\"ListTag\"," +
-				"\"value\":{\"type\":\"ByteTag\",\"list\":[{\"type\":\"ByteTag\",\"value\":123}]}}}}", ct.toString());
+				"\"value\":{\"type\":\"ByteTag\",\"list\":[123]}}}}", ct.toString());
 	}
 
 	public void testEquals() {

--- a/src/test/java/net/querz/nbt/IntArrayTagTest.java
+++ b/src/test/java/net/querz/nbt/IntArrayTagTest.java
@@ -10,7 +10,6 @@ public class IntArrayTagTest extends NBTTestCase {
 		assertEquals(11, t.getID());
 		assertEquals("[I;-2147483648,0,2147483647]", t.toTagString());
 		assertEquals("{\"type\":\"" + t.getClass().getSimpleName() + "\",\"value\":[-2147483648,0,2147483647]}", t.toString());
-		assertThrowsRuntimeException(() -> t.arrayToString(null, "", ""), UnsupportedOperationException.class);
 	}
 
 	public void testEquals() {

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -154,7 +154,7 @@ public class ListTagTest extends NBTTestCase {
 		assertThrowsNoRuntimeException(l::asLongArrayTagList);
 		assertThrowsRuntimeException(l::asListTagList, ClassCastException.class);
 
-		ListTag<ListTag<?>> lis = new ListTag<>();
+		ListTag<ListTag> lis = new ListTag<>();
 		lis.add(new ListTag<>());
 		assertThrowsNoRuntimeException(lis::asListTagList);
 		assertThrowsRuntimeException(lis::asCompoundTagList, ClassCastException.class);
@@ -182,10 +182,10 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testMaxDepth() {
-		ListTag<ListTag<?>> root = new ListTag<>();
-		ListTag<ListTag<?>> rec = root;
+		ListTag<ListTag> root = new ListTag<>();
+		ListTag<ListTag> rec = root;
 		for (int i = 0; i < Tag.MAX_DEPTH + 1; i++) {
-			ListTag<ListTag<?>> l = new ListTag<>();
+			ListTag<ListTag> l = new ListTag<>();
 			rec.add(l);
 			rec = l;
 		}
@@ -198,7 +198,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testRecursion() {
-		ListTag<ListTag<?>> recursive = new ListTag<>();
+		ListTag<ListTag> recursive = new ListTag<>();
 		recursive.add(recursive);
 		assertThrowsRuntimeException(() -> serialize(recursive), MaxDepthReachedException.class);
 		assertThrowsRuntimeException(recursive::toString, MaxDepthReachedException.class);

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -84,7 +84,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testCasting() {
-		ListTag<ByteTag> b = new ListTag<>();
+		ListTag<ByteTag> b = new ListTag<>(ByteTag.class);
 		assertThrowsNoRuntimeException(() -> b.addShort((short) 123));
 		assertThrowsRuntimeException(() -> b.addByte((byte) 123), IllegalArgumentException.class);
 		assertThrowsNoRuntimeException(b::asShortTagList);
@@ -92,15 +92,17 @@ public class ListTagTest extends NBTTestCase {
 		assertThrowsNoRuntimeException(() -> b.asTypedList(ShortTag.class));
 		assertThrowsRuntimeException(() -> b.asTypedList(ByteTag.class), ClassCastException.class);
 		b.remove(0);
+		//list is empty, type is 0 (EndTag), but it should still remember its type
 		assertEquals(0, b.getTypeID());
 		assertEquals(EndTag.class, b.getTypeClass());
-		b.addByte((byte) 1);
-		assertEquals(1, b.getTypeID());
-		assertEquals(ByteTag.class, b.getTypeClass());
+		assertThrowsRuntimeException(() -> b.addByte((byte) 1), IllegalArgumentException.class);
+		assertEquals(0, b.getTypeID());
+		assertEquals(EndTag.class, b.getTypeClass());
 		b.clear();
 		assertEquals(0, b.getTypeID());
 		assertEquals(EndTag.class, b.getTypeClass());
 
+		//adjust ListTag type during deserialization
 		ListTag<?> l = new ListTag<>();
 		assertThrowsNoRuntimeException(l::asByteTagList);
 		l.addByte(Byte.MAX_VALUE);

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -30,9 +30,9 @@ public class ListTagTest extends NBTTestCase {
 				"\"value\":{" +
 				"\"type\":\"ByteTag\"," +
 				"\"list\":[" +
-				"{\"type\":\"ByteTag\",\"value\":-128}," +
-				"{\"type\":\"ByteTag\",\"value\":0}," +
-				"{\"type\":\"ByteTag\",\"value\":127}]}}", bl.toString());
+				"-128," +
+				"0," +
+				"127]}}", bl.toString());
 	}
 
 	public void testEquals() {

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -1,7 +1,6 @@
 package net.querz.nbt;
 
 import junit.framework.TestCase;
-
 import java.util.Arrays;
 import java.util.Comparator;
 

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import static org.junit.Assert.assertNotEquals;
 
 public class ListTagTest extends NBTTestCase {
+
 	public void testCreateInvalidList() {
 		assertThrowsException(() -> new ListTag<>(EndTag.class), IllegalArgumentException.class);
 		assertThrowsException(() -> new ListTag<>(null), NullPointerException.class);
@@ -33,6 +34,8 @@ public class ListTagTest extends NBTTestCase {
 				"-128," +
 				"0," +
 				"127]}}", bl.toString());
+		ListTag<?> lu = ListTag.createUnchecked();
+		assertEquals("{\"type\":\"ListTag\",\"value\":{\"type\":\"EndTag\",\"list\":[]}}", lu.toString());
 	}
 
 	public void testEquals() {
@@ -61,6 +64,17 @@ public class ListTagTest extends NBTTestCase {
 		il.addInt(1);
 		il.clear();
 		assertEquals(il, new ListTag<>(IntTag.class));
+
+		// test empty untyped list
+		ListTag<?> lu = ListTag.createUnchecked();
+		ListTag<?> lu2 = ListTag.createUnchecked();
+		assertTrue(lu.equals(lu2));
+		lu2.asIntTagList();
+		assertFalse(lu.equals(lu2));
+		ListTag<IntTag> lie = new ListTag<>(IntTag.class);
+		assertFalse(lu.equals(lie));
+		lu.asIntTagList();
+		assertTrue(lie.equals(lu));
 	}
 
 	public void testHashCode() {

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -5,9 +5,13 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 public class ListTagTest extends NBTTestCase {
-
+	public void testCreateInvalidList() {
+		assertThrowsException(() -> new ListTag<>(EndTag.class), IllegalArgumentException.class);
+		assertThrowsException(() -> new ListTag<>(null), NullPointerException.class);
+	}
+	
 	private ListTag<ByteTag> createListTag() {
-		ListTag<ByteTag> bl = new ListTag<>();
+		ListTag<ByteTag> bl = new ListTag<>(ByteTag.class);
 		bl.add(new ByteTag(Byte.MIN_VALUE));
 		bl.add(new ByteTag((byte) 0));
 		bl.add(new ByteTag(Byte.MAX_VALUE));
@@ -33,24 +37,29 @@ public class ListTagTest extends NBTTestCase {
 	public void testEquals() {
 		ListTag<ByteTag> bl = createListTag();
 
-		ListTag<ByteTag> bl2 = new ListTag<>();
+		ListTag<ByteTag> bl2 = new ListTag<>(ByteTag.class);
 		bl2.addByte(Byte.MIN_VALUE);
 		bl2.addByte((byte) 0);
 		bl2.addByte(Byte.MAX_VALUE);
 		assertTrue(bl.equals(bl2));
 
-		ListTag<ByteTag> bl3 = new ListTag<>();
+		ListTag<ByteTag> bl3 = new ListTag<>(ByteTag.class);
 		bl2.addByte(Byte.MAX_VALUE);
 		bl2.addByte((byte) 0);
 		bl2.addByte(Byte.MIN_VALUE);
 		assertFalse(bl.equals(bl3));
 
-		ListTag<ByteTag> bl4 = new ListTag<>();
+		ListTag<ByteTag> bl4 = new ListTag<>(ByteTag.class);
 		bl2.addByte(Byte.MIN_VALUE);
 		bl2.addByte((byte) 0);
 		assertFalse(bl.equals(bl4));
 
 		assertEquals(bl, bl);
+		
+		ListTag<IntTag> il = new ListTag<>(IntTag.class);
+		il.addInt(1);
+		il.clear();
+		assertEquals(il, new ListTag<>(IntTag.class));
 	}
 
 	public void testClone() {
@@ -73,7 +82,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testSerializeDeserializeEmptyList() {
-		ListTag<IntTag> empty = new ListTag<>();
+		ListTag<IntTag> empty = new ListTag<>(IntTag.class);
 		byte[] data = serialize(empty);
 		assertTrue(Arrays.equals(new byte[]{9, 0, 0, 0, 0, 0, 0, 0}, data));
 		ListTag<?> et = (ListTag<?>) deserialize(data);
@@ -102,73 +111,73 @@ public class ListTagTest extends NBTTestCase {
 		assertEquals(EndTag.class, b.getTypeClass());
 
 		//adjust ListTag type during deserialization
-		ListTag<?> l = new ListTag<>();
+		ListTag<?> l = ListTag.createUnchecked();
 		assertThrowsNoRuntimeException(l::asByteTagList);
 		l.addByte(Byte.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asByteTagList);
 		assertThrowsRuntimeException(l::asShortTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addShort(Short.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asShortTagList);
 		assertThrowsRuntimeException(l::asIntTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addInt(Integer.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asIntTagList);
 		assertThrowsRuntimeException(l::asLongTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addLong(Long.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asLongTagList);
 		assertThrowsRuntimeException(l::asFloatTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addFloat(Float.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asFloatTagList);
 		assertThrowsRuntimeException(l::asDoubleTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addDouble(Double.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asDoubleTagList);
 		assertThrowsRuntimeException(l::asStringTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addString("foo");
 		assertThrowsNoRuntimeException(l::asStringTagList);
 		assertThrowsRuntimeException(l::asByteArrayTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addByteArray(new byte[]{Byte.MIN_VALUE, 0, Byte.MAX_VALUE});
 		assertThrowsNoRuntimeException(l::asByteArrayTagList);
 		assertThrowsRuntimeException(l::asIntArrayTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addIntArray(new int[]{Integer.MIN_VALUE, 0, Integer.MAX_VALUE});
 		assertThrowsNoRuntimeException(l::asIntArrayTagList);
 		assertThrowsRuntimeException(l::asLongArrayTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addLongArray(new long[]{Long.MIN_VALUE, 0, Long.MAX_VALUE});
 		assertThrowsNoRuntimeException(l::asLongArrayTagList);
 		assertThrowsRuntimeException(l::asListTagList, ClassCastException.class);
 
-		ListTag<ListTag> lis = new ListTag<>();
-		lis.add(new ListTag<>());
+		ListTag<ListTag<?>> lis = new ListTag<>(ListTag.class);
+		lis.add(new ListTag<>(IntTag.class));
 		assertThrowsNoRuntimeException(lis::asListTagList);
 		assertThrowsRuntimeException(lis::asCompoundTagList, ClassCastException.class);
 
-		ListTag<CompoundTag> lco = new ListTag<>();
+		ListTag<CompoundTag> lco = new ListTag<>(CompoundTag.class);
 		lco.add(new CompoundTag());
 		assertThrowsNoRuntimeException(lco::asCompoundTagList);
 		assertThrowsRuntimeException(lco::asByteTagList, ClassCastException.class);
 	}
 
 	public void testCompareTo() {
-		ListTag<IntTag> li = new ListTag<>();
+		ListTag<IntTag> li = new ListTag<>(IntTag.class);
 		li.addInt(1);
 		li.addInt(2);
-		ListTag<IntTag> lo = new ListTag<>();
+		ListTag<IntTag> lo = new ListTag<>(IntTag.class);
 		lo.addInt(3);
 		lo.addInt(4);
 		assertEquals(0, li.compareTo(lo));
@@ -181,10 +190,10 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testMaxDepth() {
-		ListTag<ListTag> root = new ListTag<>();
-		ListTag<ListTag> rec = root;
+		ListTag<ListTag<?>> root = new ListTag<>(ListTag.class);
+		ListTag<ListTag<?>> rec = root;
 		for (int i = 0; i < Tag.MAX_DEPTH + 1; i++) {
-			ListTag<ListTag> l = new ListTag<>();
+			ListTag<ListTag<?>> l = new ListTag<>(ListTag.class);
 			rec.add(l);
 			rec = l;
 		}
@@ -197,7 +206,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testRecursion() {
-		ListTag<ListTag> recursive = new ListTag<>();
+		ListTag<ListTag<?>> recursive = new ListTag<>(ListTag.class);
 		recursive.add(recursive);
 		assertThrowsRuntimeException(() -> serialize(recursive), MaxDepthReachedException.class);
 		assertThrowsRuntimeException(recursive::toString, MaxDepthReachedException.class);
@@ -205,7 +214,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testContains() {
-		ListTag<IntTag> l = new ListTag<>();
+		ListTag<IntTag> l = new ListTag<>(IntTag.class);
 		l.addInt(1);
 		l.addInt(2);
 		assertTrue(l.contains(new IntTag(1)));
@@ -215,7 +224,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testSort() {
-		ListTag<IntTag> l = new ListTag<>();
+		ListTag<IntTag> l = new ListTag<>(IntTag.class);
 		l.addInt(2);
 		l.addInt(1);
 		l.sort(Comparator.comparingInt(NumberTag::asInt));
@@ -224,7 +233,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testIterator() {
-		ListTag<IntTag> l = new ListTag<>();
+		ListTag<IntTag> l = new ListTag<>(IntTag.class);
 		l.addInt(1);
 		l.addInt(2);
 		for (IntTag i : l) {
@@ -263,7 +272,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testAdd() {
-		ListTag<ByteTag> l = new ListTag<>();
+		ListTag<ByteTag> l = new ListTag<>(ByteTag.class);
 		l.addBoolean(true);
 		assertThrowsRuntimeException(() -> l.addShort((short) 5), IllegalArgumentException.class);
 		assertEquals(1, l.size());
@@ -271,39 +280,39 @@ public class ListTagTest extends NBTTestCase {
 		l.addByte(Byte.MAX_VALUE);
 		assertEquals(2, l.size());
 		assertEquals(Byte.MAX_VALUE, l.get(1).asByte());
-		ListTag<ShortTag> s = new ListTag<>();
+		ListTag<ShortTag> s = new ListTag<>(ShortTag.class);
 		s.addShort(Short.MAX_VALUE);
 		assertEquals(1, s.size());
 		assertEquals(Short.MAX_VALUE, s.get(0).asShort());
-		ListTag<IntTag> i = new ListTag<>();
+		ListTag<IntTag> i = new ListTag<>(IntTag.class);
 		i.addInt(Integer.MAX_VALUE);
 		assertEquals(1, i.size());
 		assertEquals(Integer.MAX_VALUE, i.get(0).asInt());
-		ListTag<LongTag> lo = new ListTag<>();
+		ListTag<LongTag> lo = new ListTag<>(LongTag.class);
 		lo.addLong(Long.MAX_VALUE);
 		assertEquals(1, lo.size());
 		assertEquals(Long.MAX_VALUE, lo.get(0).asLong());
-		ListTag<FloatTag> f = new ListTag<>();
+		ListTag<FloatTag> f = new ListTag<>(FloatTag.class);
 		f.addFloat(Float.MAX_VALUE);
 		assertEquals(1, f.size());
 		assertEquals(Float.MAX_VALUE, f.get(0).asFloat());
-		ListTag<DoubleTag> d = new ListTag<>();
+		ListTag<DoubleTag> d = new ListTag<>(DoubleTag.class);
 		d.addDouble(Double.MAX_VALUE);
 		assertEquals(1, d.size());
 		assertEquals(Double.MAX_VALUE, d.get(0).asDouble());
-		ListTag<StringTag> st = new ListTag<>();
+		ListTag<StringTag> st = new ListTag<>(StringTag.class);
 		st.addString("foo");
 		assertEquals(1, st.size());
 		assertEquals("foo", st.get(0).getValue());
-		ListTag<ByteArrayTag> ba = new ListTag<>();
+		ListTag<ByteArrayTag> ba = new ListTag<>(ByteArrayTag.class);
 		ba.addByteArray(new byte[] {Byte.MIN_VALUE, 0, Byte.MAX_VALUE});
 		assertEquals(1, ba.size());
 		assertTrue(Arrays.equals(new byte[] {Byte.MIN_VALUE, 0, Byte.MAX_VALUE}, ba.get(0).getValue()));
-		ListTag<IntArrayTag> ia = new ListTag<>();
+		ListTag<IntArrayTag> ia = new ListTag<>(IntArrayTag.class);
 		ia.addIntArray(new int[] {Integer.MIN_VALUE, 0, Integer.MAX_VALUE});
 		assertEquals(1, ia.size());
 		assertTrue(Arrays.equals(new int[] {Integer.MIN_VALUE, 0, Integer.MAX_VALUE}, ia.get(0).getValue()));
-		ListTag<LongArrayTag> la = new ListTag<>();
+		ListTag<LongArrayTag> la = new ListTag<>(LongArrayTag.class);
 		la.addLongArray(new long[] {Long.MIN_VALUE, 0, Long.MAX_VALUE});
 		assertEquals(1, la.size());
 		assertTrue(Arrays.equals(new long[] {Long.MIN_VALUE, 0, Long.MAX_VALUE}, la.get(0).getValue()));

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -63,12 +63,19 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testClone() {
-		ListTag<ByteTag> bl = createListTag();
+		ListTag<IntTag> i = new ListTag<>(IntTag.class);
+		ListTag<IntTag> c = i.clone();
+		assertThrowsRuntimeException(() -> c.addString("wrong type in clone"), IllegalArgumentException.class);
+		c.addInt(123);
+		assertFalse(i.equals(c));
+		c.clear();
+		assertTrue(i.equals(c));
+		assertFalse(invokeGetValue(i) == invokeGetValue(c));
 
-		ListTag<ByteTag> tc = bl.clone();
-		assertTrue(bl.equals(tc));
-		assertFalse(bl == tc);
-		assertFalse(invokeGetValue(bl) == invokeGetValue(tc));
+		i.addInt(123);
+		ListTag<IntTag> c2 = i.clone();
+		assertTrue(i.equals(c2));
+		assertFalse(invokeGetValue(i) == invokeGetValue(c2));
 	}
 
 	public void testSerializeDeserialize() {

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -85,17 +85,17 @@ public class ListTagTest extends NBTTestCase {
 
 	public void testCasting() {
 		ListTag<ByteTag> b = new ListTag<>(ByteTag.class);
-		assertThrowsNoRuntimeException(() -> b.addShort((short) 123));
-		assertThrowsRuntimeException(() -> b.addByte((byte) 123), IllegalArgumentException.class);
-		assertThrowsNoRuntimeException(b::asShortTagList);
-		assertThrowsRuntimeException(b::asByteTagList, ClassCastException.class);
-		assertThrowsNoRuntimeException(() -> b.asTypedList(ShortTag.class));
-		assertThrowsRuntimeException(() -> b.asTypedList(ByteTag.class), ClassCastException.class);
+		assertThrowsRuntimeException(() -> b.addShort((short) 123), IllegalArgumentException.class);
+		assertThrowsNoRuntimeException(() -> b.addByte((byte) 123));
+		assertThrowsNoRuntimeException(b::asByteTagList);
+		assertThrowsRuntimeException(b::asShortTagList, ClassCastException.class);
+		assertThrowsNoRuntimeException(() -> b.asTypedList(ByteTag.class));
+		assertThrowsRuntimeException(() -> b.asTypedList(ShortTag.class), ClassCastException.class);
 		b.remove(0);
 		//list is empty, type is 0 (EndTag), but it should still remember its type
 		assertEquals(0, b.getTypeID());
 		assertEquals(EndTag.class, b.getTypeClass());
-		assertThrowsRuntimeException(() -> b.addByte((byte) 1), IllegalArgumentException.class);
+		assertThrowsRuntimeException(() -> b.addShort((short) 1), IllegalArgumentException.class);
 		assertEquals(0, b.getTypeID());
 		assertEquals(EndTag.class, b.getTypeClass());
 		b.clear();

--- a/src/test/java/net/querz/nbt/LongArrayTagTest.java
+++ b/src/test/java/net/querz/nbt/LongArrayTagTest.java
@@ -10,7 +10,6 @@ public class LongArrayTagTest extends NBTTestCase {
 		assertEquals(12, t.getID());
 		assertEquals("[L;-9223372036854775808l,0l,9223372036854775807l]", t.toTagString());
 		assertEquals("{\"type\":\"" + t.getClass().getSimpleName() + "\",\"value\":[-9223372036854775808,0,9223372036854775807]}", t.toString());
-		assertThrowsRuntimeException(() -> t.arrayToString(null, "", ""), UnsupportedOperationException.class);
 	}
 
 	public void testEquals() {

--- a/src/test/java/net/querz/nbt/NBTTestCase.java
+++ b/src/test/java/net/querz/nbt/NBTTestCase.java
@@ -28,7 +28,7 @@ public abstract class NBTTestCase extends TestCase {
 		TagFactory.unregisterCustomTag(100);
 		TagFactory.unregisterCustomTag(110);
 		TagFactory.unregisterCustomTag(120);
-		cleanupTmpDir();
+//		cleanupTmpDir();
 	}
 
 	protected byte[] serialize(Tag<?> tag) {
@@ -151,10 +151,16 @@ public abstract class NBTTestCase extends TestCase {
 	}
 
 	protected <T, E extends Exception> T assertThrowsNoException(ExceptionSupplier<T, E> r) {
+		return assertThrowsNoException(r, false);
+	}
+
+	protected <T, E extends Exception> T assertThrowsNoException(ExceptionSupplier<T, E> r, boolean printStackTrace) {
 		try {
 			return r.run();
 		} catch (Exception ex) {
-			ex.printStackTrace();
+			if (printStackTrace) {
+				ex.printStackTrace();
+			}
 			TestCase.fail("Threw exception " + ex.getClass().getName() + " with message \"" + ex.getMessage() + "\"");
 		}
 		return null;
@@ -216,6 +222,15 @@ public abstract class NBTTestCase extends TestCase {
 			tmpFile = new File(tmpDir, UUID.randomUUID() + name);
 		}
 		return tmpFile;
+	}
+
+	protected File getTmpFile(String name) {
+		String workingDir = System.getProperty("user.dir");
+		File tmpDir = new File(workingDir, "tmp");
+		if (!tmpDir.exists()) {
+			tmpDir.mkdirs();
+		}
+		return new File(tmpDir, name);
 	}
 
 	protected File copyResourceToTmp(String resource) {

--- a/src/test/java/net/querz/nbt/NBTTestCase.java
+++ b/src/test/java/net/querz/nbt/NBTTestCase.java
@@ -31,7 +31,7 @@ public abstract class NBTTestCase extends TestCase {
 		cleanupTmpDir();
 	}
 
-	protected byte[] serialize(Tag tag) {
+	protected byte[] serialize(Tag<?> tag) {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try (DataOutputStream dos = new DataOutputStream(baos)) {
 			tag.serialize(dos, 0);
@@ -42,7 +42,7 @@ public abstract class NBTTestCase extends TestCase {
 		return baos.toByteArray();
 	}
 
-	protected Tag deserialize(byte[] data) {
+	protected Tag<?> deserialize(byte[] data) {
 		try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
 			return Tag.deserialize(dis, 0);
 		} catch (IOException ex) {
@@ -58,7 +58,7 @@ public abstract class NBTTestCase extends TestCase {
 		return new File(resource.getFile());
 	}
 
-	protected Tag deserializeFromFile(String f) {
+	protected Tag<?> deserializeFromFile(String f) {
 		try (DataInputStream dis = new DataInputStream(new FileInputStream(getResourceFile(f)))) {
 			return Tag.deserialize(dis, 0);
 		} catch (IOException ex) {
@@ -109,11 +109,11 @@ public abstract class NBTTestCase extends TestCase {
 		return null;
 	}
 
-	protected void assertThrowsException(ExceptionRunnable r, Class<? extends Exception> e) {
+	protected <E extends Exception> void assertThrowsException(ExceptionRunnable<E> r, Class<? extends Exception> e) {
 		assertThrowsException(r, e, false);
 	}
 
-	protected void assertThrowsException(ExceptionRunnable r, Class<? extends Exception> e, boolean printStackTrace) {
+	protected <E extends Exception> void assertThrowsException(ExceptionRunnable<E> r, Class<? extends Exception> e, boolean printStackTrace) {
 		try {
 			r.run();
 			TestCase.fail();
@@ -125,7 +125,7 @@ public abstract class NBTTestCase extends TestCase {
 		}
 	}
 
-	protected void assertThrowsNoException(ExceptionRunnable r) {
+	protected <E extends Exception> void assertThrowsNoException(ExceptionRunnable<E> r) {
 		try {
 			r.run();
 		} catch (Exception ex) {
@@ -134,11 +134,11 @@ public abstract class NBTTestCase extends TestCase {
 		}
 	}
 
-	protected void assertThrowsException(ExceptionSupplier r, Class<? extends Exception> e) {
+	protected <T, E extends Exception> void assertThrowsException(ExceptionSupplier<T, E> r, Class<? extends Exception> e) {
 		assertThrowsException(r, e, false);
 	}
 
-	protected void assertThrowsException(ExceptionSupplier r, Class<? extends Exception> e, boolean printStackTrace) {
+	protected <T, E extends Exception> void assertThrowsException(ExceptionSupplier<T, E> r, Class<? extends Exception> e, boolean printStackTrace) {
 		try {
 			r.run();
 			TestCase.fail();

--- a/src/test/java/net/querz/nbt/TagFactoryTest.java
+++ b/src/test/java/net/querz/nbt/TagFactoryTest.java
@@ -21,10 +21,20 @@ public class TagFactoryTest extends NBTTestCase {
 		assertThrowsRuntimeException(() -> TagFactory.fromID(-1), IllegalArgumentException.class);
 	}
 
+	public void testClassFromID() {
+		assertThrowsNoRuntimeException(() -> TagFactory.classFromID(1));
+		assertThrowsRuntimeException(() -> TagFactory.classFromID(20), IllegalArgumentException.class);
+	}
+
+	public void testIDFromClass() {
+		assertThrowsNoRuntimeException(() -> TagFactory.idFromClass(ByteTag.class));
+		assertThrowsRuntimeException(() -> TagFactory.idFromClass(CharTag.class), IllegalArgumentException.class);
+	}
+
 	public void testRegisterCustomTag() {
-		assertThrowsRuntimeException(() -> TagFactory.registerCustomTag(-1, CharTag::new), IllegalArgumentException.class);
-		assertThrowsRuntimeException(() -> TagFactory.registerCustomTag(12, CharTag::new), IllegalArgumentException.class);
-		assertThrowsRuntimeException(() -> TagFactory.registerCustomTag(128, CharTag::new), IllegalArgumentException.class);
+		assertThrowsRuntimeException(() -> TagFactory.registerCustomTag(-1, CharTag::new, CharTag.class), IllegalArgumentException.class);
+		assertThrowsRuntimeException(() -> TagFactory.registerCustomTag(12, CharTag::new, CharTag.class), IllegalArgumentException.class);
+		assertThrowsRuntimeException(() -> TagFactory.registerCustomTag(128, CharTag::new, CharTag.class), IllegalArgumentException.class);
 		CharTag.register();
 		assertThrowsRuntimeException(CharTag::register, IllegalArgumentException.class);
 	}

--- a/src/test/java/net/querz/nbt/TagTest.java
+++ b/src/test/java/net/querz/nbt/TagTest.java
@@ -62,5 +62,14 @@ public class TagTest extends NBTTestCase {
 		assertThrowsException(() -> NBTUtil.writeTag(null, (File) null), NullPointerException.class);
 		assertThrowsException(() -> NBTUtil.writeTag(null, null, (File) null, false), NullPointerException.class);
 		assertThrowsException(() -> NBTUtil.writeTag(null, null, (String) null, false), NullPointerException.class);
+
+		CompoundTag dummy = new CompoundTag();
+		assertThrowsNoException(() -> NBTUtil.writeTag(dummy, getNewTmpFile("coverage.dat")));
+		assertThrowsNoException(() -> NBTUtil.writeTag(dummy, getNewTmpFile("coverage.dat").getAbsolutePath()));
+		assertThrowsNoException(() -> NBTUtil.writeTag(dummy, getNewTmpFile("coverage.dat"), true));
+		assertThrowsNoException(() -> NBTUtil.writeTag(dummy, getNewTmpFile("coverage.dat").getAbsolutePath(), true));
+		assertThrowsNoException(() -> NBTUtil.writeTag(dummy, "foo", getNewTmpFile("coverage.dat")));
+		assertThrowsNoException(() -> NBTUtil.writeTag(dummy, "foo", getNewTmpFile("coverage.dat").getAbsolutePath()));
+		assertThrowsNoException(() -> NBTUtil.writeTag(dummy, "foo", getNewTmpFile("coverage.dat").getAbsolutePath(), true));
 	}
 }

--- a/src/test/java/net/querz/nbt/custom/CharTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/CharTagTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 public class CharTagTest extends NBTTestCase {
 
 	public void testStringConversion() {
+		CharTag.register();
 		CharTag t = new CharTag('a');
 		assertEquals('a', (char) t.getValue());
 		assertEquals(110, t.getID());

--- a/src/test/java/net/querz/nbt/custom/ObjectTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/ObjectTagTest.java
@@ -114,7 +114,7 @@ public class ObjectTagTest extends NBTTestCase implements Serializable {
 	}
 
 	public void testUnknownObject() {
-		TagFactory.registerCustomTag(90, ObjectTag::new);
+		TagFactory.registerCustomTag(90, ObjectTag::new, ObjectTag.class);
 		assertThrowsException(() -> NBTUtil.readTag(getResourceFile("unknown_object_tag.dat")), IOException.class);
 	}
 

--- a/src/test/java/net/querz/nbt/custom/ObjectTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/ObjectTagTest.java
@@ -12,6 +12,7 @@ import java.util.Random;
 public class ObjectTagTest extends NBTTestCase implements Serializable {
 
 	public void testStringConversion() {
+		ObjectTag.register();
 		DummyObject d = new DummyObject();
 		ObjectTag<DummyObject> o = new ObjectTag<>(d);
 		assertEquals(90, o.getID());

--- a/src/test/java/net/querz/nbt/custom/ShortArrayTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/ShortArrayTagTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotEquals;
 public class ShortArrayTagTest extends NBTTestCase {
 
 	public void testStringConversion() {
+		ShortArrayTag.register();
 		ShortArrayTag t = new ShortArrayTag(new short[]{Short.MIN_VALUE, 0, Short.MAX_VALUE});
 		assertTrue(Arrays.equals(new short[]{Short.MIN_VALUE, 0, Short.MAX_VALUE}, t.getValue()));
 		assertEquals(100, t.getID());

--- a/src/test/java/net/querz/nbt/custom/StructTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/StructTagTest.java
@@ -3,6 +3,7 @@ package net.querz.nbt.custom;
 import junit.framework.TestCase;
 import net.querz.nbt.ByteTag;
 import net.querz.nbt.CompoundTag;
+import net.querz.nbt.EndTag;
 import net.querz.nbt.IntTag;
 import net.querz.nbt.ListTag;
 import net.querz.nbt.LongTag;
@@ -180,9 +181,9 @@ public class StructTagTest extends NBTTestCase {
 		assertEquals(1, co.size());
 		assertEquals(new CompoundTag(), co.getCompoundTag(0));
 		StructTag li = new StructTag();
-		li.add(new ListTag<>());
+		li.add(new ListTag<>(EndTag.class));
 		assertEquals(1, li.size());
-		assertEquals(new ListTag<>(), li.getListTag(0));
+		assertEquals(new ListTag<>(EndTag.class), li.getListTag(0));
 
 		StructTag t = new StructTag();
 		t.add(0, new StringTag("foo"));

--- a/src/test/java/net/querz/nbt/custom/StructTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/StructTagTest.java
@@ -22,6 +22,7 @@ public class StructTagTest extends NBTTestCase {
 	}
 
 	public void testStringConversion() {
+		StructTag.register();
 		StructTag s = createStructTag();
 		assertEquals(120, s.getID());
 		assertEquals("[127b,2147483647]", s.toTagString());

--- a/src/test/java/net/querz/nbt/custom/StructTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/StructTagTest.java
@@ -3,7 +3,6 @@ package net.querz.nbt.custom;
 import junit.framework.TestCase;
 import net.querz.nbt.ByteTag;
 import net.querz.nbt.CompoundTag;
-import net.querz.nbt.EndTag;
 import net.querz.nbt.IntTag;
 import net.querz.nbt.ListTag;
 import net.querz.nbt.LongTag;
@@ -103,7 +102,7 @@ public class StructTagTest extends NBTTestCase {
 		StructTag l = new StructTag();
 		l.addInt(1);
 		l.addLong(2);
-		for (Tag t : l) {
+		for (Tag<?> t : l) {
 			assertNotNull(t);
 		}
 		l.forEach(TestCase::assertNotNull);
@@ -181,9 +180,9 @@ public class StructTagTest extends NBTTestCase {
 		assertEquals(1, co.size());
 		assertEquals(new CompoundTag(), co.getCompoundTag(0));
 		StructTag li = new StructTag();
-		li.add(new ListTag<>(EndTag.class));
+		li.add(new ListTag<>(IntTag.class));
 		assertEquals(1, li.size());
-		assertEquals(new ListTag<>(EndTag.class), li.getListTag(0));
+		assertEquals(new ListTag<>(IntTag.class), li.getListTag(0));
 
 		StructTag t = new StructTag();
 		t.add(0, new StringTag("foo"));

--- a/src/test/java/net/querz/nbt/mca/MCAFileTest.java
+++ b/src/test/java/net/querz/nbt/mca/MCAFileTest.java
@@ -1,16 +1,10 @@
 package net.querz.nbt.mca;
 
-import net.querz.nbt.ByteTag;
 import net.querz.nbt.CompoundTag;
 import net.querz.nbt.ListTag;
-
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.file.Files;
 import java.util.Arrays;
 
 public class MCAFileTest extends MCATestCase {
@@ -95,7 +89,7 @@ public class MCAFileTest extends MCATestCase {
 		assertNotNull(f.getChunk(0).getBiomes());
 		assertNull(f.getChunk(0).getHeightMaps());
 		assertNull(f.getChunk(0).getCarvingMasks());
-		assertEquals(new ListTag<>(), f.getChunk(0).getEntities());
+		assertEquals(new ListTag<>(CompoundTag.class), f.getChunk(0).getEntities());
 		assertNull(f.getChunk(0).getTileEntities());
 		assertNull(f.getChunk(0).getTileTicks());
 		assertNull(f.getChunk(0).getLiquidTicks());

--- a/src/test/java/net/querz/nbt/mca/MCATestCase.java
+++ b/src/test/java/net/querz/nbt/mca/MCATestCase.java
@@ -35,8 +35,8 @@ public abstract class MCATestCase extends NBTTestCase {
 		return l;
 	}
 
-	public ListTag<ListTag> getSomeListTagList() {
-		ListTag<ListTag> l = new ListTag<>(ListTag.class);
+	public ListTag<ListTag<?>> getSomeListTagList() {
+		ListTag<ListTag<?>> l = new ListTag<>(ListTag.class);
 		l.add(getSomeCompoundTagList());
 		l.add(getSomeCompoundTagList());
 		return l;

--- a/src/test/java/net/querz/nbt/mca/MCATestCase.java
+++ b/src/test/java/net/querz/nbt/mca/MCATestCase.java
@@ -29,14 +29,14 @@ public abstract class MCATestCase extends NBTTestCase {
 	}
 
 	public ListTag<CompoundTag> getSomeCompoundTagList() {
-		ListTag<CompoundTag> l = new ListTag<>();
+		ListTag<CompoundTag> l = new ListTag<>(CompoundTag.class);
 		l.add(getSomeCompoundTag());
 		l.add(getSomeCompoundTag());
 		return l;
 	}
 
 	public ListTag<ListTag<?>> getSomeListTagList() {
-		ListTag<ListTag<?>> l = new ListTag<>();
+		ListTag<ListTag<?>> l = new ListTag<>(ListTag.class);
 		l.add(getSomeCompoundTagList());
 		l.add(getSomeCompoundTagList());
 		return l;

--- a/src/test/java/net/querz/nbt/mca/MCATestCase.java
+++ b/src/test/java/net/querz/nbt/mca/MCATestCase.java
@@ -35,8 +35,8 @@ public abstract class MCATestCase extends NBTTestCase {
 		return l;
 	}
 
-	public ListTag<ListTag<?>> getSomeListTagList() {
-		ListTag<ListTag<?>> l = new ListTag<>(ListTag.class);
+	public ListTag<ListTag> getSomeListTagList() {
+		ListTag<ListTag> l = new ListTag<>(ListTag.class);
 		l.add(getSomeCompoundTagList());
 		l.add(getSomeCompoundTagList());
 		return l;

--- a/src/test/java/net/querz/nbt/mca/MCAUtilTest.java
+++ b/src/test/java/net/querz/nbt/mca/MCAUtilTest.java
@@ -80,6 +80,12 @@ public class MCAUtilTest extends MCATestCase {
 		assertThrowsException(() -> MCAUtil.writeMCAFile(null, (File) null), NullPointerException.class);
 		assertThrowsException(() -> MCAUtil.writeMCAFile(null, (String) null, false), NullPointerException.class);
 		assertThrowsException(() -> MCAUtil.readMCAFile("r.a.b.mca"), IllegalArgumentException.class);
-		assertThrowsException(() -> new MCAFile(0, 0).serialize(null), NullPointerException.class);
+		assertThrowsNoException(() -> new MCAFile(0, 0).serialize(null)); // empty MCAFile will not even attempt to write to file
+
+		// test overwriting file
+		MCAFile m = new MCAFile(0, 0);
+		m.setChunk(0, Chunk.newChunk());
+		assertThrowsNoException(() -> MCAUtil.writeMCAFile(m, getTmpFile("r.0.0.mca"), false), true);
+		assertThrowsNoException(() -> MCAUtil.writeMCAFile(m, getTmpFile("r.0.0.mca"), false), true);
 	}
 }


### PR DESCRIPTION
See #14 
`ListTag` should remember its type when cleared.

The current solution makes the no-args constructor of `ListTag` protected so deserialisation can still create an instance without knowing the type of the `ListTag`. Everything from outside creating a new instance of `ListTag` will need to use `ListTag(Class<T extends Tag>)`.

I also modified `ListTag#getTypeID()` and `ListTag#getTypeClass()` to match the old behaviour and be consistent with serialisation. Another reason for this is that these methods cannot be consistent with each other when the `ListTag` is empty.
Example:
```java
ListTag<IntTag> l = new ListTag<>(IntTag.class);
```
can only set the type class of the `ListTag`, but not the type id. Setting the type id occurs when adding the first element to the new `ListTag`.
Therefore `ListTag#getTypeID()` will return `0` and `ListTag#getTypeClass()` returns `EndTag.class` when the `ListTag` is empty.

---
Other cases that will fail now but worked before:
```java
ListTag<IntTag> l = new ListTag<>(IntTag.class);
l.addByte((byte) 123); // will now throw an IllegalArgumentException
```
```java
ListTag<IntTag> l = new ListTag<>(IntTag.class);
l.addInt(123);
l.clear();
l.addByte((byte) 123); // will now throw an IllegalArgumentException
```

The behaviour of `ListTag#asTypedList(Class<? extends Tag>)` also matches the new behaviour.

---
All Unit Tests have been adjusted.