### PR TITLE
Made ListTag more type-safe

### DIFF
--- a/src/main/java/net/querz/nbt/TagFactory.java
+++ b/src/main/java/net/querz/nbt/TagFactory.java
@@ -31,7 +31,7 @@ public class TagFactory {
 			case 8:
 				return new StringTag();
 			case 9:
-				return new ListTag();
+				return ListTag.createUnchecked();
 			case 10:
 				return new CompoundTag();
 			case 11:

--- a/src/test/java/net/querz/nbt/CompoundTagTest.java
+++ b/src/test/java/net/querz/nbt/CompoundTagTest.java
@@ -12,7 +12,7 @@ public class CompoundTagTest extends NBTTestCase {
 		invokeSetValue(ct, new LinkedHashMap<>());
 		ct.put("b", new ByteTag(Byte.MAX_VALUE));
 		ct.put("str", new StringTag("foo"));
-		ct.put("list", new ListTag<>());
+		ct.put("list", new ListTag<>(ByteTag.class));
 		ct.getListTag("list").addByte((byte) 123);
 		return ct;
 	}
@@ -33,7 +33,7 @@ public class CompoundTagTest extends NBTTestCase {
 		CompoundTag ct2 = new CompoundTag();
 		ct2.putByte("b", Byte.MAX_VALUE);
 		ct2.putString("str", "foo");
-		ct2.put("list", new ListTag<>());
+		ct2.put("list", new ListTag<>(ByteTag.class));
 		ct2.getListTag("list").addByte((byte) 123);
 		assertTrue(ct.equals(ct2));
 
@@ -75,7 +75,7 @@ public class CompoundTagTest extends NBTTestCase {
 			t.putIntArray("key_int_array" + i, iArray);
 			t.putLongArray("key_long_array" + i, lArray);
 
-			ListTag<StringTag> l = new ListTag<>();
+			ListTag<StringTag> l = new ListTag<>(StringTag.class);
 			for (int j = 0; j < 256; j++) {
 				l.addString("value" + j);
 			}
@@ -111,7 +111,7 @@ public class CompoundTagTest extends NBTTestCase {
 			t2.putIntArray("key_int_array" + i, iArray);
 			t2.putLongArray("key_long_array" + i, lArray);
 
-			ListTag<StringTag> l = new ListTag<>();
+			ListTag<StringTag> l = new ListTag<>(StringTag.class);
 			for (int j = 0; j < 256; j++) {
 				l.addString("value" + j);
 			}
@@ -238,8 +238,8 @@ public class CompoundTagTest extends NBTTestCase {
 		assertThrowsRuntimeException(() -> cc.getListTag("la"), ClassCastException.class);
 		assertTrue(Arrays.equals(new long[0], cc.getLongArray("lala")));
 
-		cc.put("li", new ListTag<>());
-		assertEquals(new ListTag<>(), cc.getListTag("li"));
+		cc.put("li", new ListTag<>(IntTag.class));
+		assertEquals(new ListTag<>(IntTag.class), cc.getListTag("li"));
 		assertNull(cc.getListTag("lili"));
 		assertThrowsRuntimeException(() -> cc.getCompoundTag("li"), ClassCastException.class);
 
@@ -308,7 +308,7 @@ public class CompoundTagTest extends NBTTestCase {
 		assertTrue(ct.containsKey("list"));
 		assertFalse(ct.containsKey("invalid"));
 		assertTrue(ct.containsValue(new StringTag("foo")));
-		ListTag<ByteTag> l = new ListTag<>();
+		ListTag<ByteTag> l = new ListTag<>(ByteTag.class);
 		l.addByte((byte) 123);
 		assertTrue(ct.containsValue(l));
 		assertTrue(ct.containsValue(new ByteTag(Byte.MAX_VALUE)));

--- a/src/test/java/net/querz/nbt/ListTagTest.java
+++ b/src/test/java/net/querz/nbt/ListTagTest.java
@@ -5,9 +5,13 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 public class ListTagTest extends NBTTestCase {
-
+	public void testCreateInvalidList() {
+		assertThrowsException(() -> new ListTag<>(EndTag.class), IllegalArgumentException.class);
+		assertThrowsException(() -> new ListTag<>(null), NullPointerException.class);
+	}
+	
 	private ListTag<ByteTag> createListTag() {
-		ListTag<ByteTag> bl = new ListTag<>();
+		ListTag<ByteTag> bl = new ListTag<>(ByteTag.class);
 		bl.add(new ByteTag(Byte.MIN_VALUE));
 		bl.add(new ByteTag((byte) 0));
 		bl.add(new ByteTag(Byte.MAX_VALUE));
@@ -33,24 +37,29 @@ public class ListTagTest extends NBTTestCase {
 	public void testEquals() {
 		ListTag<ByteTag> bl = createListTag();
 
-		ListTag<ByteTag> bl2 = new ListTag<>();
+		ListTag<ByteTag> bl2 = new ListTag<>(ByteTag.class);
 		bl2.addByte(Byte.MIN_VALUE);
 		bl2.addByte((byte) 0);
 		bl2.addByte(Byte.MAX_VALUE);
 		assertTrue(bl.equals(bl2));
 
-		ListTag<ByteTag> bl3 = new ListTag<>();
+		ListTag<ByteTag> bl3 = new ListTag<>(ByteTag.class);
 		bl2.addByte(Byte.MAX_VALUE);
 		bl2.addByte((byte) 0);
 		bl2.addByte(Byte.MIN_VALUE);
 		assertFalse(bl.equals(bl3));
 
-		ListTag<ByteTag> bl4 = new ListTag<>();
+		ListTag<ByteTag> bl4 = new ListTag<>(ByteTag.class);
 		bl2.addByte(Byte.MIN_VALUE);
 		bl2.addByte((byte) 0);
 		assertFalse(bl.equals(bl4));
 
 		assertEquals(bl, bl);
+		
+		ListTag<IntTag> il = new ListTag<>(IntTag.class);
+		il.addInt(1);
+		il.clear();
+		assertEquals(il, new ListTag<IntTag>(IntTag.class));
 	}
 
 	public void testClone() {
@@ -73,7 +82,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testSerializeDeserializeEmptyList() {
-		ListTag<IntTag> empty = new ListTag<>();
+		ListTag<IntTag> empty = new ListTag<>(IntTag.class);
 		byte[] data = serialize(empty);
 		assertTrue(Arrays.equals(new byte[]{9, 0, 0, 0, 0, 0, 0, 0}, data));
 		ListTag<?> et = (ListTag<?>) deserialize(data);
@@ -102,73 +111,73 @@ public class ListTagTest extends NBTTestCase {
 		assertEquals(EndTag.class, b.getTypeClass());
 
 		//adjust ListTag type during deserialization
-		ListTag<?> l = new ListTag<>();
+		ListTag<?> l = ListTag.createUnchecked();
 		assertThrowsNoRuntimeException(l::asByteTagList);
 		l.addByte(Byte.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asByteTagList);
 		assertThrowsRuntimeException(l::asShortTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addShort(Short.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asShortTagList);
 		assertThrowsRuntimeException(l::asIntTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addInt(Integer.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asIntTagList);
 		assertThrowsRuntimeException(l::asLongTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addLong(Long.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asLongTagList);
 		assertThrowsRuntimeException(l::asFloatTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addFloat(Float.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asFloatTagList);
 		assertThrowsRuntimeException(l::asDoubleTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addDouble(Double.MAX_VALUE);
 		assertThrowsNoRuntimeException(l::asDoubleTagList);
 		assertThrowsRuntimeException(l::asStringTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addString("foo");
 		assertThrowsNoRuntimeException(l::asStringTagList);
 		assertThrowsRuntimeException(l::asByteArrayTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addByteArray(new byte[]{Byte.MIN_VALUE, 0, Byte.MAX_VALUE});
 		assertThrowsNoRuntimeException(l::asByteArrayTagList);
 		assertThrowsRuntimeException(l::asIntArrayTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addIntArray(new int[]{Integer.MIN_VALUE, 0, Integer.MAX_VALUE});
 		assertThrowsNoRuntimeException(l::asIntArrayTagList);
 		assertThrowsRuntimeException(l::asLongArrayTagList, ClassCastException.class);
 
-		l = new ListTag<>();
+		l = ListTag.createUnchecked();
 		l.addLongArray(new long[]{Long.MIN_VALUE, 0, Long.MAX_VALUE});
 		assertThrowsNoRuntimeException(l::asLongArrayTagList);
 		assertThrowsRuntimeException(l::asListTagList, ClassCastException.class);
 
-		ListTag<ListTag> lis = new ListTag<>();
-		lis.add(new ListTag<>());
+		ListTag<ListTag> lis = new ListTag<>(ListTag.class);
+		lis.add(new ListTag<>(IntTag.class));
 		assertThrowsNoRuntimeException(lis::asListTagList);
 		assertThrowsRuntimeException(lis::asCompoundTagList, ClassCastException.class);
 
-		ListTag<CompoundTag> lco = new ListTag<>();
+		ListTag<CompoundTag> lco = new ListTag<>(CompoundTag.class);
 		lco.add(new CompoundTag());
 		assertThrowsNoRuntimeException(lco::asCompoundTagList);
 		assertThrowsRuntimeException(lco::asByteTagList, ClassCastException.class);
 	}
 
 	public void testCompareTo() {
-		ListTag<IntTag> li = new ListTag<>();
+		ListTag<IntTag> li = new ListTag<>(IntTag.class);
 		li.addInt(1);
 		li.addInt(2);
-		ListTag<IntTag> lo = new ListTag<>();
+		ListTag<IntTag> lo = new ListTag<>(IntTag.class);
 		lo.addInt(3);
 		lo.addInt(4);
 		assertEquals(0, li.compareTo(lo));
@@ -181,10 +190,10 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testMaxDepth() {
-		ListTag<ListTag> root = new ListTag<>();
+		ListTag<ListTag> root = new ListTag<>(ListTag.class);
 		ListTag<ListTag> rec = root;
 		for (int i = 0; i < Tag.MAX_DEPTH + 1; i++) {
-			ListTag<ListTag> l = new ListTag<>();
+			ListTag<ListTag> l = new ListTag<>(ListTag.class);
 			rec.add(l);
 			rec = l;
 		}
@@ -197,7 +206,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testRecursion() {
-		ListTag<ListTag> recursive = new ListTag<>();
+		ListTag<ListTag> recursive = new ListTag<>(ListTag.class);
 		recursive.add(recursive);
 		assertThrowsRuntimeException(() -> serialize(recursive), MaxDepthReachedException.class);
 		assertThrowsRuntimeException(recursive::toString, MaxDepthReachedException.class);
@@ -205,7 +214,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testContains() {
-		ListTag<IntTag> l = new ListTag<>();
+		ListTag<IntTag> l = new ListTag<>(IntTag.class);
 		l.addInt(1);
 		l.addInt(2);
 		assertTrue(l.contains(new IntTag(1)));
@@ -215,7 +224,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testSort() {
-		ListTag<IntTag> l = new ListTag<>();
+		ListTag<IntTag> l = new ListTag<>(IntTag.class);
 		l.addInt(2);
 		l.addInt(1);
 		l.sort(Comparator.comparingInt(NumberTag::asInt));
@@ -224,7 +233,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testIterator() {
-		ListTag<IntTag> l = new ListTag<>();
+		ListTag<IntTag> l = new ListTag<>(IntTag.class);
 		l.addInt(1);
 		l.addInt(2);
 		for (IntTag i : l) {
@@ -263,7 +272,7 @@ public class ListTagTest extends NBTTestCase {
 	}
 
 	public void testAdd() {
-		ListTag<ByteTag> l = new ListTag<>();
+		ListTag<ByteTag> l = new ListTag<>(ByteTag.class);
 		l.addBoolean(true);
 		assertThrowsRuntimeException(() -> l.addShort((short) 5), IllegalArgumentException.class);
 		assertEquals(1, l.size());
@@ -271,39 +280,39 @@ public class ListTagTest extends NBTTestCase {
 		l.addByte(Byte.MAX_VALUE);
 		assertEquals(2, l.size());
 		assertEquals(Byte.MAX_VALUE, l.get(1).asByte());
-		ListTag<ShortTag> s = new ListTag<>();
+		ListTag<ShortTag> s = new ListTag<>(ShortTag.class);
 		s.addShort(Short.MAX_VALUE);
 		assertEquals(1, s.size());
 		assertEquals(Short.MAX_VALUE, s.get(0).asShort());
-		ListTag<IntTag> i = new ListTag<>();
+		ListTag<IntTag> i = new ListTag<>(IntTag.class);
 		i.addInt(Integer.MAX_VALUE);
 		assertEquals(1, i.size());
 		assertEquals(Integer.MAX_VALUE, i.get(0).asInt());
-		ListTag<LongTag> lo = new ListTag<>();
+		ListTag<LongTag> lo = new ListTag<>(LongTag.class);
 		lo.addLong(Long.MAX_VALUE);
 		assertEquals(1, lo.size());
 		assertEquals(Long.MAX_VALUE, lo.get(0).asLong());
-		ListTag<FloatTag> f = new ListTag<>();
+		ListTag<FloatTag> f = new ListTag<>(FloatTag.class);
 		f.addFloat(Float.MAX_VALUE);
 		assertEquals(1, f.size());
 		assertEquals(Float.MAX_VALUE, f.get(0).asFloat());
-		ListTag<DoubleTag> d = new ListTag<>();
+		ListTag<DoubleTag> d = new ListTag<>(DoubleTag.class);
 		d.addDouble(Double.MAX_VALUE);
 		assertEquals(1, d.size());
 		assertEquals(Double.MAX_VALUE, d.get(0).asDouble());
-		ListTag<StringTag> st = new ListTag<>();
+		ListTag<StringTag> st = new ListTag<>(StringTag.class);
 		st.addString("foo");
 		assertEquals(1, st.size());
 		assertEquals("foo", st.get(0).getValue());
-		ListTag<ByteArrayTag> ba = new ListTag<>();
+		ListTag<ByteArrayTag> ba = new ListTag<>(ByteArrayTag.class);
 		ba.addByteArray(new byte[] {Byte.MIN_VALUE, 0, Byte.MAX_VALUE});
 		assertEquals(1, ba.size());
 		assertTrue(Arrays.equals(new byte[] {Byte.MIN_VALUE, 0, Byte.MAX_VALUE}, ba.get(0).getValue()));
-		ListTag<IntArrayTag> ia = new ListTag<>();
+		ListTag<IntArrayTag> ia = new ListTag<>(IntArrayTag.class);
 		ia.addIntArray(new int[] {Integer.MIN_VALUE, 0, Integer.MAX_VALUE});
 		assertEquals(1, ia.size());
 		assertTrue(Arrays.equals(new int[] {Integer.MIN_VALUE, 0, Integer.MAX_VALUE}, ia.get(0).getValue()));
-		ListTag<LongArrayTag> la = new ListTag<>();
+		ListTag<LongArrayTag> la = new ListTag<>(LongArrayTag.class);
 		la.addLongArray(new long[] {Long.MIN_VALUE, 0, Long.MAX_VALUE});
 		assertEquals(1, la.size());
 		assertTrue(Arrays.equals(new long[] {Long.MIN_VALUE, 0, Long.MAX_VALUE}, la.get(0).getValue()));

--- a/src/test/java/net/querz/nbt/custom/StructTagTest.java
+++ b/src/test/java/net/querz/nbt/custom/StructTagTest.java
@@ -181,9 +181,9 @@ public class StructTagTest extends NBTTestCase {
 		assertEquals(1, co.size());
 		assertEquals(new CompoundTag(), co.getCompoundTag(0));
 		StructTag li = new StructTag();
-		li.add(new ListTag<>(EndTag.class));
+		li.add(new ListTag<>(IntTag.class));
 		assertEquals(1, li.size());
-		assertEquals(new ListTag<>(EndTag.class), li.getListTag(0));
+		assertEquals(new ListTag<>(IntTag.class), li.getListTag(0));
 
 		StructTag t = new StructTag();
 		t.add(0, new StringTag("foo"));


### PR DESCRIPTION
- Made no-args non-type-safe constructor private and added protected method instead to prevent accidential usage
- Fixed being able to create EndTag lists (since they are not type-safe)
- Fixed empty list and list.add().clear() not being equal due to typeID difference
- Fixed clone() creating non-type-safe list if this list is empty