### PR TITLE
Add Automatic-Module-Name manifest attribute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,3 +53,9 @@ artifacts {
 	archives sourcesJar
 	archives javadocJar
 }
+
+jar {
+	manifest {
+		attributes('Automatic-Module-Name': 'net.querz.nbt')
+	}
+}


### PR DESCRIPTION
This PR adds the `Automatic-Module-Name` attribute to the manifest of the final jar.

The value of this attribute is used to name automatic modules from jars that don't support Jigsaw (yet).

Without this explicit automatic module name, the module name resolved to `NBT`, but `net.querz.nbt` seems more appropriate.