### PR TITLE
Improve the reader and writer helpers

### DIFF
--- a/src/main/java/net/querz/nbt/io/NBTUtil.java
+++ b/src/main/java/net/querz/nbt/io/NBTUtil.java
@@ -1,134 +1,269 @@
 package net.querz.nbt.io;
 
 import net.querz.nbt.tag.Tag;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PushbackInputStream;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.zip.GZIPInputStream;
 
 public final class NBTUtil {
 
 	private NBTUtil() {}
 
+	/**
+	 * Writer helper that follows the builder pattern.
+	 * <p>
+	 * Usage example:
+	 * <pre>{@code Writer.write()
+	 *     .tag(nbtTag)
+	 *     .littleEndian()
+	 *     .compressed(false)
+	 *     .to("file.schematic")}</pre>
+	 */
+	public static class Writer {
+
+		private NamedTag tag;
+		private boolean compressed = true;
+		private boolean littleEndian = false;
+
+		public Writer() {
+		}
+
+		public static Writer write() {
+			return new Writer();
+		}
+
+		public Writer tag(NamedTag tag) {
+			this.tag = tag;
+			return this;
+		}
+
+		public Writer tag(Tag<?> tag) {
+			this.tag = new NamedTag(null, tag);
+			return this;
+		}
+
+		public Writer compressed(boolean compressed) {
+			this.compressed = compressed;
+			return this;
+		}
+
+		public Writer littleEndian() {
+			this.littleEndian = true;
+			return this;
+		}
+
+		public Writer bigEndian() {
+			this.littleEndian = false;
+			return this;
+		}
+
+		public void to(OutputStream os) throws IOException {
+			if (tag == null)
+				throw new IllegalStateException("tag must be set");
+			if (os == null)
+				throw new IllegalStateException("output must be set");
+
+			new NBTSerializer(compressed, littleEndian).toStream(tag, os);
+		}
+
+		public void to(Path path) throws IOException {
+			try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(path))) {
+				to(os);
+			}
+		}
+
+		public void to(File file) throws IOException {
+			to(file.toPath());
+		}
+
+		public void to(String file) throws IOException {
+			to(Paths.get(file));
+		}
+	}
+
+	/**
+	 * Reader helper that follows the builder pattern.
+	 * <p>
+	 * Usage example:
+	 * <pre>{@code Reader.read()
+	 *     .littleEndian()
+	 *     .from("file.schematic")}</pre>
+	 */
+	public static class Reader {
+
+		private boolean littleEndian = false;
+
+		public Reader() {
+		}
+
+		public static Reader read() {
+			return new Reader();
+		}
+
+		public Reader littleEndian() {
+			this.littleEndian = true;
+			return this;
+		}
+
+		public Reader bigEndian() {
+			this.littleEndian = false;
+			return this;
+		}
+
+		public NamedTag from(InputStream is) throws IOException {
+			return new NBTDeserializer(false/* ignored, will autodetect compression */, littleEndian)
+					.fromStream(detectDecompression(is));
+		}
+
+		public NamedTag from(Path path) throws IOException {
+			try (InputStream is = new BufferedInputStream(Files.newInputStream(path))) {
+				return from(is);
+			}
+		}
+
+		public NamedTag from(File file) throws IOException {
+			return from(file.toPath());
+		}
+
+		public NamedTag from(String file) throws IOException {
+			return from(Paths.get(file));
+		}
+
+		private static InputStream detectDecompression(InputStream is) throws IOException {
+			PushbackInputStream pbis = new PushbackInputStream(is, 2);
+			int signature = (pbis.read() & 0xFF) + (pbis.read() << 8);
+			pbis.unread(signature >> 8);
+			pbis.unread(signature & 0xFF);
+			return signature == GZIPInputStream.GZIP_MAGIC ? new GZIPInputStream(pbis) : pbis;
+		}
+	}
+
+
+	@Deprecated
 	public static void write(NamedTag tag, File file, boolean compressed) throws IOException {
-		try (FileOutputStream fos = new FileOutputStream(file)) {
-			new NBTSerializer(compressed).toStream(tag, fos);
-		}
+		Writer.write().tag(tag).compressed(compressed).to(file);
 	}
 
+	@Deprecated
 	public static void write(NamedTag tag, String file, boolean compressed) throws IOException {
-		write(tag, new File(file), compressed);
+		Writer.write().tag(tag).compressed(compressed).to(file);
 	}
 
+	@Deprecated
 	public static void write(NamedTag tag, File file) throws IOException {
-		write(tag, file, true);
+		Writer.write().tag(tag).to(file);
 	}
 
+	@Deprecated
 	public static void write(NamedTag tag, String file) throws IOException {
-		write(tag, new File(file), true);
+		Writer.write().tag(tag).to(file);
 	}
 
+	@Deprecated
 	public static void write(Tag<?> tag, File file, boolean compressed) throws IOException {
-		write(new NamedTag(null, tag), file, compressed);
+		Writer.write().tag(tag).compressed(compressed).to(file);
 	}
 
+	@Deprecated
 	public static void write(Tag<?> tag, String file, boolean compressed) throws IOException {
-		write(new NamedTag(null, tag), new File(file), compressed);
+		Writer.write().tag(tag).compressed(compressed).to(file);
 	}
 
+	@Deprecated
 	public static void write(Tag<?> tag, File file) throws IOException {
-		write(new NamedTag(null, tag), file, true);
+		Writer.write().tag(tag).to(file);
 	}
 
+	@Deprecated
 	public static void write(Tag<?> tag, String file) throws IOException {
-		write(new NamedTag(null, tag), new File(file), true);
+		Writer.write().tag(tag).to(file);
 	}
 
+	@Deprecated
 	public static void writeLE(NamedTag tag, File file, boolean compressed) throws IOException {
-		try (FileOutputStream fos = new FileOutputStream(file)) {
-			new NBTSerializer(compressed, true).toStream(tag, fos);
-		}
+		Writer.write().tag(tag).littleEndian().compressed(compressed).to(file);
 	}
 
+	@Deprecated
 	public static void writeLE(NamedTag tag, String file, boolean compressed) throws IOException {
-		writeLE(tag, new File(file), compressed);
+		Writer.write().tag(tag).littleEndian().compressed(compressed).to(file);
 	}
 
+	@Deprecated
 	public static void writeLE(NamedTag tag, File file) throws IOException {
-		writeLE(tag, file, true);
+		Writer.write().tag(tag).littleEndian().to(file);
 	}
 
+	@Deprecated
 	public static void writeLE(NamedTag tag, String file) throws IOException {
-		writeLE(tag, new File(file), true);
+		Writer.write().tag(tag).littleEndian().to(file);
 	}
 
+	@Deprecated
 	public static void writeLE(Tag<?> tag, File file, boolean compressed) throws IOException {
-		writeLE(new NamedTag(null, tag), file, compressed);
+		Writer.write().tag(tag).littleEndian().compressed(compressed).to(file);
 	}
 
+	@Deprecated
 	public static void writeLE(Tag<?> tag, String file, boolean compressed) throws IOException {
-		writeLE(new NamedTag(null, tag), new File(file), compressed);
+		Writer.write().tag(tag).littleEndian().compressed(compressed).to(file);
 	}
 
+	@Deprecated
 	public static void writeLE(Tag<?> tag, File file) throws IOException {
-		writeLE(new NamedTag(null, tag), file, true);
+		Writer.write().tag(tag).littleEndian().to(file);
 	}
 
+	@Deprecated
 	public static void writeLE(Tag<?> tag, String file) throws IOException {
-		writeLE(new NamedTag(null, tag), new File(file), true);
+		Writer.write().tag(tag).littleEndian().to(file);
 	}
 
+	@Deprecated
+	@SuppressWarnings("unused")
 	public static NamedTag read(File file, boolean compressed) throws IOException {
-		try (FileInputStream fis = new FileInputStream(file)) {
-			return new NBTDeserializer(compressed).fromStream(fis);
-		}
+		return Reader.read().from(file);
 	}
 
+	@Deprecated
+	@SuppressWarnings("unused")
 	public static NamedTag read(String file, boolean compressed) throws IOException {
-		return read(new File(file), compressed);
+		return Reader.read().from(file);
 	}
 
+	@Deprecated
 	public static NamedTag read(File file) throws IOException {
-		try (FileInputStream fis = new FileInputStream(file)) {
-			return new NBTDeserializer(false).fromStream(detectDecompression(fis));
-		}
+		return Reader.read().from(file);
 	}
 
+	@Deprecated
 	public static NamedTag read(String file) throws IOException {
-		return read(new File(file));
+		return Reader.read().from(file);
 	}
 
+	@Deprecated
+	@SuppressWarnings("unused")
 	public static NamedTag readLE(File file, boolean compressed) throws IOException {
-		try (FileInputStream fis = new FileInputStream(file)) {
-			return new NBTDeserializer(compressed, true).fromStream(fis);
-		}
+		return Reader.read().littleEndian().from(file);
 	}
 
+	@Deprecated
+	@SuppressWarnings("unused")
 	public static NamedTag readLE(String file, boolean compressed) throws IOException {
-		return readLE(new File(file), compressed);
+		return Reader.read().littleEndian().from(file);
 	}
 
+	@Deprecated
 	public static NamedTag readLE(File file) throws IOException {
-		try (FileInputStream fis = new FileInputStream(file)) {
-			return new NBTDeserializer(false, true).fromStream(detectDecompression(fis));
-		}
+		return Reader.read().littleEndian().from(file);
 	}
 
+	@Deprecated
 	public static NamedTag readLE(String file) throws IOException {
-		return readLE(new File(file));
+		return Reader.read().littleEndian().from(file);
 	}
 
-	private static InputStream detectDecompression(InputStream is) throws IOException {
-		PushbackInputStream pbis = new PushbackInputStream(is, 2);
-		int signature = (pbis.read() & 0xFF) + (pbis.read() << 8);
-		pbis.unread(signature >> 8);
-		pbis.unread(signature & 0xFF);
-		if (signature == GZIPInputStream.GZIP_MAGIC) {
-			return new GZIPInputStream(pbis);
-		}
-		return pbis;
-	}
 }

--- a/src/test/java/net/querz/nbt/io/NBTUtilTest.java
+++ b/src/test/java/net/querz/nbt/io/NBTUtilTest.java
@@ -1,0 +1,125 @@
+package net.querz.nbt.io;
+
+import java.io.*;
+
+import net.querz.nbt.io.NBTUtil.Reader;
+import net.querz.nbt.io.NBTUtil.Writer;
+import net.querz.nbt.tag.StringTag;
+import net.querz.nbt.tag.Tag;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NBTUtilTest {
+
+	public static final StringTag TAG = new StringTag("TEST");
+
+	public static final boolean DEFAULT_COMPRESSED = true;
+	public static final boolean DEFAULT_LITTLE_ENDIAN = false;
+
+	protected static byte[] serialize(Tag<?> tag, boolean compressed, boolean littleEndian) {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try (DataOutputStream dos = new DataOutputStream(baos)) {
+			new NBTSerializer(compressed, littleEndian).toStream(new NamedTag(null, tag), dos);
+		} catch (IOException ex) {
+			ex.printStackTrace();
+			fail(ex.getMessage());
+		}
+		return baos.toByteArray();
+	}
+
+	@Test
+	public void testWriter_invalidParams() throws IOException {
+		try {
+			Writer.write().tag((NamedTag) null).to(new ByteArrayOutputStream());
+			fail("did not check null tag");
+		} catch (IllegalStateException ignored) { }
+
+		try {
+			Writer.write().tag(TAG).to((OutputStream) null);
+			fail("did not check null output stream");
+		} catch (IllegalStateException ignored) { }
+	}
+
+	@Test
+	public void testWriter_compressionEnabled() throws IOException {
+		final boolean compressed = true;
+		final ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+		Writer.write().tag(TAG).compressed(compressed).to(os);
+
+		assertArrayEquals(serialize(TAG, compressed, DEFAULT_LITTLE_ENDIAN), os.toByteArray());
+	}
+
+	@Test
+	public void testWriter_compressionDisabled() throws IOException {
+		final boolean compressed = false;
+		final ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+		Writer.write().tag(TAG).compressed(compressed).to(os);
+
+		assertArrayEquals(serialize(TAG, compressed, DEFAULT_LITTLE_ENDIAN), os.toByteArray());
+	}
+
+	@Test
+	public void testReader_compressionEnabled() throws IOException {
+		final boolean compressed = true;
+		final InputStream is = new ByteArrayInputStream(serialize(TAG, compressed, DEFAULT_LITTLE_ENDIAN));
+
+		final NamedTag tag = Reader.read().from(is);
+
+		assertEquals(TAG, tag.getTag());
+	}
+
+	@Test
+	public void testReader_compressionDisabled() throws IOException {
+		final boolean compressed = false;
+		final InputStream is = new ByteArrayInputStream(serialize(TAG, compressed, DEFAULT_LITTLE_ENDIAN));
+
+		final NamedTag tag = Reader.read().from(is);
+
+		assertEquals(TAG, tag.getTag());
+	}
+
+
+	@Test
+	public void testWriter_littleEndian() throws IOException {
+		final boolean littleEndian = true;
+		final ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+		Writer.write().tag(TAG).littleEndian().to(os);
+
+		assertArrayEquals(serialize(TAG, DEFAULT_COMPRESSED, littleEndian), os.toByteArray());
+	}
+
+	@Test
+	public void testWriter_bigEndian() throws IOException {
+		final boolean littleEndian = false;
+		final ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+		Writer.write().tag(TAG).bigEndian().to(os);
+
+		assertArrayEquals(serialize(TAG, DEFAULT_COMPRESSED, littleEndian), os.toByteArray());
+	}
+
+	@Test
+	public void testReader_littleEndian() throws IOException {
+		final boolean littleEndian = true;
+		final InputStream is = new ByteArrayInputStream(serialize(TAG, DEFAULT_COMPRESSED, littleEndian));
+
+		final NamedTag tag = Reader.read().littleEndian().from(is);
+
+		assertEquals(TAG, tag.getTag());
+	}
+
+	@Test
+	public void testReader_bigEndian() throws IOException {
+		final boolean littleEndian = false;
+		final InputStream is = new ByteArrayInputStream(serialize(TAG, DEFAULT_COMPRESSED, littleEndian));
+
+		final NamedTag tag = Reader.read().bigEndian().from(is);
+
+		assertEquals(TAG, tag.getTag());
+	}
+
+}


### PR DESCRIPTION
Added support for Input/OutputStreams and created helpful builders. Also wrapped the file methods on buffered streams to improve reading/writing performance.

Here is an example:
```java
// with the current implementation
NBTUtil.writeLE(tag, "out.schematic", true);

// with the new builder
NBTUtil.Writer.write().tag(tag).littleEndian().compressed(true).to("out.schematic");
```