### PR TITLE
Add initial capacity to List and Compound tags

### DIFF
--- a/src/main/java/net/querz/nbt/tag/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/tag/CompoundTag.java
@@ -282,7 +282,7 @@ public class CompoundTag extends Tag<Map<String, Tag<?>>>
 
 	@Override
 	public CompoundTag clone() {
-		CompoundTag copy = new CompoundTag(((int) Math.ceil(getValue().size() * 1.75f)) + 1);
+		CompoundTag copy = new CompoundTag((int) Math.ceil(getValue().size() * 1.33f));
 		for (Map.Entry<String, Tag<?>> e : getValue().entrySet()) {
 			copy.put(e.getKey(), e.getValue().clone());
 		}

--- a/src/main/java/net/querz/nbt/tag/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/tag/CompoundTag.java
@@ -1,7 +1,5 @@
 package net.querz.nbt.tag;
 
-import net.querz.io.MaxDepthIO;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -10,12 +8,19 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
-public class CompoundTag extends Tag<Map<String, Tag<?>>> implements Iterable<Map.Entry<String, Tag<?>>>, Comparable<CompoundTag>, MaxDepthIO {
+import net.querz.io.MaxDepthIO;
+
+public class CompoundTag extends Tag<Map<String, Tag<?>>>
+		implements Iterable<Map.Entry<String, Tag<?>>>, Comparable<CompoundTag>, MaxDepthIO {
 
 	public static final byte ID = 10;
 
 	public CompoundTag() {
 		super(createEmptyValue());
+	}
+
+	public CompoundTag(int initialCapacity) {
+		super(new HashMap<>(initialCapacity));
 	}
 
 	@Override

--- a/src/main/java/net/querz/nbt/tag/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/tag/CompoundTag.java
@@ -282,7 +282,7 @@ public class CompoundTag extends Tag<Map<String, Tag<?>>>
 
 	@Override
 	public CompoundTag clone() {
-		CompoundTag copy = new CompoundTag();
+		CompoundTag copy = new CompoundTag(((int) Math.ceil(getValue().size() * 1.75f)) + 1);
 		for (Map.Entry<String, Tag<?>> e : getValue().entrySet()) {
 			copy.put(e.getKey(), e.getValue().clone());
 		}

--- a/src/main/java/net/querz/nbt/tag/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/tag/CompoundTag.java
@@ -282,7 +282,8 @@ public class CompoundTag extends Tag<Map<String, Tag<?>>>
 
 	@Override
 	public CompoundTag clone() {
-		CompoundTag copy = new CompoundTag((int) Math.ceil(getValue().size() * 1.33f));
+		// Choose initial capacity based on default load factor (0.75) so all entries fit in map without resizing
+		CompoundTag copy = new CompoundTag((int) Math.ceil(getValue().size() / 0.75f));
 		for (Map.Entry<String, Tag<?>> e : getValue().entrySet()) {
 			copy.put(e.getKey(), e.getValue().clone());
 		}

--- a/src/main/java/net/querz/nbt/tag/ListTag.java
+++ b/src/main/java/net/querz/nbt/tag/ListTag.java
@@ -320,7 +320,7 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 	@SuppressWarnings("unchecked")
 	@Override
 	public ListTag<T> clone() {
-		ListTag<T> copy = new ListTag<>(((int) Math.ceil(this.size() * 1.75)) + 1);
+		ListTag<T> copy = new ListTag<>(this.size());
 		// assure type safety for clone
 		copy.typeClass = typeClass;
 		for (T t : getValue()) {

--- a/src/main/java/net/querz/nbt/tag/ListTag.java
+++ b/src/main/java/net/querz/nbt/tag/ListTag.java
@@ -1,7 +1,5 @@
 package net.querz.nbt.tag;
 
-import net.querz.io.MaxDepthIO;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -10,38 +8,53 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import net.querz.io.MaxDepthIO;
+
 /**
  * ListTag represents a typed List in the nbt structure.
  * An empty {@link ListTag} will be of type {@link EndTag} (unknown type).
  * The type of an empty untyped {@link ListTag} can be set by using any of the {@code add()}
  * methods or any of the {@code as...List()} methods.
- * */
+ */
 public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<T>, Comparable<ListTag<T>>, MaxDepthIO {
 
 	public static final byte ID = 9;
 
 	private Class<?> typeClass = null;
 
-	private ListTag() {
-		super(createEmptyValue(3));
+	private ListTag(int initialCapacity) {
+		super(createEmptyValue(initialCapacity));
 	}
 
 	@Override
 	public byte getID() {
 		return ID;
 	}
-	
+
 	/**
-	 * <p>Creates a non-type-safe ListTag. Its element type will be set after the first 
+	 * <p>Creates a non-type-safe ListTag. Its element type will be set after the first
 	 * element was added.</p>
-	 * 
-	 * <p>This is an internal helper method for cases where the element type is not known 
+	 *
+	 * <p>This is an internal helper method for cases where the element type is not known
 	 * at construction time. Use {@link #ListTag(Class)} when the type is known.</p>
-	 * 
+	 *
 	 * @return A new non-type-safe ListTag
 	 */
 	public static ListTag<?> createUnchecked(Class<?> typeClass) {
-		ListTag<?> list = new ListTag<>();
+		return createUnchecked(typeClass, 3);
+	}
+
+	/**
+	 * <p>Creates a non-type-safe ListTag. Its element type will be set after the first
+	 * element was added.</p>
+	 *
+	 * <p>This is an internal helper method for cases where the element type is not known
+	 * at construction time. Use {@link #ListTag(Class)} when the type is known.</p>
+	 *
+	 * @return A new non-type-safe ListTag
+	 */
+	public static ListTag<?> createUnchecked(Class<?> typeClass, int initialCapacity) {
+		ListTag<?> list = new ListTag<>(initialCapacity);
 		list.typeClass = typeClass;
 		return list;
 	}
@@ -49,10 +62,10 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 	/**
 	 * <p>Creates an empty mutable list to be used as empty value of ListTags.</p>
 	 *
-	 * @param <T> Type of the list elements
+	 * @param <T>             Type of the list elements
 	 * @param initialCapacity The initial capacity of the returned List
 	 * @return An instance of {@link java.util.List} with an initial capacity of 3
-	 * */
+	 */
 	private static <T> List<T> createEmptyValue(int initialCapacity) {
 		return new ArrayList<>(initialCapacity);
 	}
@@ -60,10 +73,20 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 	/**
 	 * @param typeClass The exact class of the elements
 	 * @throws IllegalArgumentException When {@code typeClass} is {@link EndTag}{@code .class}
-	 * @throws NullPointerException When {@code typeClass} is {@code null}
+	 * @throws NullPointerException     When {@code typeClass} is {@code null}
 	 */
 	public ListTag(Class<? super T> typeClass) throws IllegalArgumentException, NullPointerException {
-		super(createEmptyValue(3));
+		this(typeClass, 3);
+	}
+
+	/**
+	 * @param typeClass       The exact class of the elements
+	 * @param initialCapacity Initial capacity of list
+	 * @throws IllegalArgumentException When {@code typeClass} is {@link EndTag}{@code .class}
+	 * @throws NullPointerException     When {@code typeClass} is {@code null}
+	 */
+	public ListTag(Class<? super T> typeClass, int initialCapacity) throws IllegalArgumentException, NullPointerException {
+		super(createEmptyValue(initialCapacity));
 		if (typeClass == EndTag.class) {
 			throw new IllegalArgumentException("cannot create ListTag with EndTag elements");
 		}
@@ -114,8 +137,9 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 
 	/**
 	 * Adds a Tag to this ListTag after the last index.
+	 *
 	 * @param t The element to be added.
-	 * */
+	 */
 	public void add(T t) {
 		add(size(), t);
 	}
@@ -271,7 +295,8 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 		if (this == other) {
 			return true;
 		}
-		if (!super.equals(other) || size() != ((ListTag<?>) other).size() || getTypeClass() != ((ListTag<?>) other).getTypeClass()) {
+		if (!super.equals(other) || size() != ((ListTag<?>) other).size() || getTypeClass() != ((ListTag<?>) other)
+				.getTypeClass()) {
 			return false;
 		}
 		for (int i = 0; i < size(); i++) {
@@ -295,7 +320,7 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 	@SuppressWarnings("unchecked")
 	@Override
 	public ListTag<T> clone() {
-		ListTag<T> copy = new ListTag<>();
+		ListTag<T> copy = new ListTag<>(this.size());
 		// assure type safety for clone
 		copy.typeClass = typeClass;
 		for (T t : getValue()) {

--- a/src/main/java/net/querz/nbt/tag/ListTag.java
+++ b/src/main/java/net/querz/nbt/tag/ListTag.java
@@ -320,7 +320,7 @@ public class ListTag<T extends Tag<?>> extends Tag<List<T>> implements Iterable<
 	@SuppressWarnings("unchecked")
 	@Override
 	public ListTag<T> clone() {
-		ListTag<T> copy = new ListTag<>(this.size());
+		ListTag<T> copy = new ListTag<>(((int) Math.ceil(this.size() * 1.75)) + 1);
 		// assure type safety for clone
 		copy.typeClass = typeClass;
 		for (T t : getValue()) {


### PR DESCRIPTION
Background
=====

While running some profiling test on some high performance code using the library we found some simple optimizations :)

Problem
=====

Resizing the backing collections for CompoundTag and ListTag can be expensive(Its a O(N) operation)


Goal
=====

Add initial capacity constructors to both classes, so if you already know the size you can create it directly with that size and avoid the resizing :D

Implementation
=====

Add new constructors that set the initial capacity

Caveats
=====

None.


Further considerations
=====

None.


ToDo list
=====

None.
