### PR TITLE
Fix Markdown typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NBT
 [![Build Status](https://travis-ci.org/Querz/NBT.svg?branch=master)](https://travis-ci.org/Querz/NBT) [![Coverage Status](https://img.shields.io/coveralls/github/Querz/NBT/master.svg)](https://coveralls.io/github/Querz/NBT?branch=master) [![Release](https://jitpack.io/v/Querz/NBT.svg)](https://jitpack.io/#Querz/NBT)
 #### A java implementation of the [NBT protocol](http://minecraft.gamepedia.com/NBT_format) for Minecraft Java Edition.
+
 ---
 ### Specification
 According to the [specification](https://minecraft.gamepedia.com/NBT_format), there are currently 13 different types of tags:


### PR DESCRIPTION
It won't render the Markdown title properly without a newline after it with some Markdown renderers (e.g. IntelliJ IDEA).