### PR TITLE
Parse single quoted SNBT Strings

### DIFF
--- a/src/main/java/net/querz/nbt/io/SNBTParser.java
+++ b/src/main/java/net/querz/nbt/io/SNBTParser.java
@@ -77,8 +77,8 @@ public final class SNBTParser implements MaxDepthIO {
 
 	private Tag<?> parseStringOrLiteral() throws ParseException {
 		ptr.skipWhitespace();
-		if (ptr.currentChar() == '"') {
-			return new StringTag(ptr.parseQuotedString());
+		if (ptr.currentChar() == '"' || ptr.currentChar() == '\'') {
+			return new StringTag(ptr.parseQuotedString(ptr.currentChar()));
 		}
 		String s = ptr.parseSimpleString();
 		if (s.isEmpty()) {
@@ -130,7 +130,7 @@ public final class SNBTParser implements MaxDepthIO {
 		ptr.skipWhitespace();
 		while (ptr.hasNext() && ptr.currentChar() != '}') {
 			ptr.skipWhitespace();
-			String key = ptr.currentChar() == '"' ? ptr.parseQuotedString() : ptr.parseSimpleString();
+			String key = ptr.currentChar() == '"' ? ptr.parseQuotedString('"') : ptr.parseSimpleString();
 			if (key.isEmpty()) {
 				throw new ParseException("empty keys are not allowed");
 			}

--- a/src/main/java/net/querz/nbt/io/StringPointer.java
+++ b/src/main/java/net/querz/nbt/io/StringPointer.java
@@ -25,14 +25,14 @@ public class StringPointer {
 		return value.substring(oldIndex, index);
 	}
 
-	public String parseQuotedString() throws ParseException {
+	public String parseQuotedString(char quoteChar) throws ParseException {
 		int oldIndex = ++index; //ignore beginning quotes
 		StringBuilder sb = null;
 		boolean escape = false;
 		while (hasNext()) {
 			char c = next();
 			if (escape) {
-				if (c != '\\' && c != '"') {
+				if (c != '\\' && c != quoteChar) {
 					throw parseException("invalid escape of '" + c + "'");
 				}
 				escape = false;
@@ -45,7 +45,7 @@ public class StringPointer {
 					sb = new StringBuilder(value.substring(oldIndex, index - 1));
 					continue;
 				}
-				if (c == '"') {
+				if (c == quoteChar) {
 					return sb == null ? value.substring(oldIndex, index - 1) : sb.toString();
 				}
 			}

--- a/src/test/java/net/querz/nbt/io/StringPointerTest.java
+++ b/src/test/java/net/querz/nbt/io/StringPointerTest.java
@@ -71,14 +71,16 @@ public class StringPointerTest extends NBTTestCase {
 	}
 
 	public void testParseQuotedString() {
-		StringPointer ptr = new StringPointer("\"abcdefg\"");
-		assertEquals("abcdefg", assertThrowsNoException(ptr::parseQuotedString));
-		ptr = new StringPointer("\"abc\\def\"");
-		assertThrowsException(ptr::parseQuotedString, ParseException.class);
-		ptr = new StringPointer("\"abc\\\\def\\\\\"");
-		assertEquals("abc\\def\\", assertThrowsNoException(ptr::parseQuotedString));
-		ptr = new StringPointer("\"abc");
-		assertThrowsException(ptr::parseQuotedString, ParseException.class);
+		StringPointer ptr0 = new StringPointer("\"abcdefg\"");
+		assertEquals("abcdefg", assertThrowsNoException(() -> ptr0.parseQuotedString('"')));
+		StringPointer ptr1 = new StringPointer("\"abc\\def\"");
+		assertThrowsException(() -> ptr1.parseQuotedString('"'), ParseException.class);
+		StringPointer ptr2 = new StringPointer("\"abc\\\\def\\\\\"");
+		assertEquals("abc\\def\\", assertThrowsNoException(() -> ptr2.parseQuotedString('"')));
+		StringPointer ptr3 = new StringPointer("'abc\\\\def\\\\'");
+		assertEquals("abc\\def\\", assertThrowsNoException(() -> ptr3.parseQuotedString('\'')));
+		StringPointer ptr4 = new StringPointer("\"abc");
+		assertThrowsException(() -> ptr4.parseQuotedString('"'), ParseException.class);
 	}
 
 	public void testParseSimpleString() {


### PR DESCRIPTION
This PR fixes strings quoted with single quotes to be parsed correctly.
Before this fix, this (valid) SNBT, for example, would not be parsed correctly
```
{id: "minecraft:diamond_sword", tag: {Damage: 0, display: {Name: '{"extra":[{"bold":true,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false,"color":"dark_green","text":"Dryad\'s "},{"bold":true,"italic":false,"color":"light_purple","text":"Flower "},{"bold":true,"italic":false,"color":"yellow","text":"Staff"}],"text":""}'}, Enchantments: [{id: "minecraft:channeling", lvl: 1s}, {id: "minecraft:infinity", lvl: 1s}]}, Count: 1b}
```
because the string at `tag.display.Name` is quoted with single quotes (Minecraft output display name strings in single quotes by default).