### PR TITLE
Fix jitpack build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ plugins {
 group 'net.querz'
 version '7.0'
 
+sourceCompatibility = JavaLanguageVersion.of(17)
+targetCompatibility = JavaLanguageVersion.of(17)
+
 repositories {
     mavenCentral()
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,6 @@
 jdk:
   - openjdk17
+
+before_install:
+  - sdk install java 17.0.3-ms
+  - sdk use java 17.0.3-ms


### PR DESCRIPTION
Jitpack is not able to build this project right now, for some reason it's no longer picking up the `jdk` option in `jitpack.yml` and defaulting to JDK 8 ([log](https://jitpack.io/com/github/Querz/NBT/05a44f873e/build.log)). This seems to be a [known issue](https://github.com/jitpack/jitpack.io/issues/4260), but they don't seem to be doing anything about it...

Anyway, using sdkman in `before_install` seems to do the trick.
In fairness to Jitpack, this "workaround" is actually mentioned in their [documentation](https://jitpack.io/docs/BUILDING/#java-version), but I don't understand why the `jdk` option still exists if it's not the way to do things...

Although not technically necessary for Jitpack, I also added source- and targetCompatibility to build.gradle for good measure :)