### PR TITLE
Prevent null keys and values and EndTag values in CompoundTag and ListTag

### DIFF
--- a/src/main/java/net/querz/nbt/ByteArrayTag.java
+++ b/src/main/java/net/querz/nbt/ByteArrayTag.java
@@ -4,12 +4,14 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 public class ByteArrayTag extends CollectionTag<ByteTag> {
 
 	private byte[] value;
 
 	public ByteArrayTag(byte[] b) {
+		Objects.requireNonNull(b);
 		value = b;
 	}
 

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -75,51 +75,53 @@ public class CompoundTag implements Tag, Iterable<Map.Entry<String, Tag>> {
 	}
 
 	public Tag put(String key, Tag tag) {
+		Objects.requireNonNull(key);
+		Objects.requireNonNull(tag);
 		return value.put(key, tag);
 	}
 
 	public void putByte(String key, byte b) {
-		value.put(key, ByteTag.valueOf(b));
+		put(key, ByteTag.valueOf(b));
 	}
 
 	public void putShort(String key, short s) {
-		value.put(key, ShortTag.valueOf(s));
+		put(key, ShortTag.valueOf(s));
 	}
 
 	public void putInt(String key, int i) {
-		value.put(key, IntTag.valueOf(i));
+		put(key, IntTag.valueOf(i));
 	}
 
 	public void putLong(String key, long l) {
-		value.put(key, LongTag.valueOf(l));
+		put(key, LongTag.valueOf(l));
 	}
 
 	public void putFloat(String key, float f) {
-		value.put(key, FloatTag.valueOf(f));
+		put(key, FloatTag.valueOf(f));
 	}
 
 	public void putDouble(String key, double d) {
-		value.put(key, DoubleTag.valueOf(d));
+		put(key, DoubleTag.valueOf(d));
 	}
 
 	public void putString(String key, String s) {
-		value.put(key, StringTag.valueOf(s));
+		put(key, StringTag.valueOf(s));
 	}
 
 	public void putByteArray(String key, byte[] b) {
-		value.put(key, new ByteArrayTag(b));
+		put(key, new ByteArrayTag(b));
 	}
 
 	public void putIntArray(String key, int[] i) {
-		value.put(key, new IntArrayTag(i));
+		put(key, new IntArrayTag(i));
 	}
 
 	public void putLongArray(String key, long[] l) {
-		value.put(key, new LongArrayTag(l));
+		put(key, new LongArrayTag(l));
 	}
 
 	public void putBoolean(String key, boolean b) {
-		value.put(key, ByteTag.valueOf(b));
+		put(key, ByteTag.valueOf(b));
 	}
 
 	public Tag get(String key) {

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -77,6 +77,9 @@ public class CompoundTag implements Tag, Iterable<Map.Entry<String, Tag>> {
 	public Tag put(String key, Tag tag) {
 		Objects.requireNonNull(key);
 		Objects.requireNonNull(tag);
+		if (tag.getID() == END) {
+			throw new IllegalArgumentException("Can't insert end tag into CompoundTag");
+		}
 		return value.put(key, tag);
 	}
 

--- a/src/main/java/net/querz/nbt/IntArrayTag.java
+++ b/src/main/java/net/querz/nbt/IntArrayTag.java
@@ -4,12 +4,14 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 public class IntArrayTag extends CollectionTag<IntTag> {
 
 	private int[] value;
 
 	public IntArrayTag(int[] i) {
+		Objects.requireNonNull(i);
 		value = i;
 	}
 

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -18,6 +18,12 @@ public class ListTag extends CollectionTag<Tag> {
 	}
 
 	public ListTag(List<Tag> list, byte type) {
+		for (int i = 0; i < list.size(); i++) {
+			if (list.get(i).getID() != type) {
+				throw new IllegalArgumentException("Incorrect tag type "+list.get(i).getID()+" at index "+i+" (expected "+type+")");
+			}
+		}
+
 		value = list;
 		this.type = type;
 	}

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -18,6 +18,9 @@ public class ListTag extends CollectionTag<Tag> {
 	}
 
 	public ListTag(List<Tag> list, byte type) {
+		Objects.requireNonNull(list);
+		list.forEach(Objects::requireNonNull);
+
 		value = list;
 		this.type = type;
 	}
@@ -29,6 +32,8 @@ public class ListTag extends CollectionTag<Tag> {
 
 	@Override
 	public Tag set(int index, Tag tag) {
+		Objects.requireNonNull(tag);
+
 		Tag old = value.get(index);
 		if (!updateType(tag)) {
 			throw new UnsupportedOperationException(String.format("trying to set tag of type %d in ListTag of %d", tag.getID(), type));
@@ -39,6 +44,8 @@ public class ListTag extends CollectionTag<Tag> {
 
 	@Override
 	public void add(int index, Tag tag) {
+		Objects.requireNonNull(tag);
+
 		if (!updateType(tag)) {
 			throw new UnsupportedOperationException(String.format("trying to add tag of type %d to ListTag of %d", tag.getID(), type));
 		}
@@ -159,7 +166,7 @@ public class ListTag extends CollectionTag<Tag> {
 		if (this == other) {
 			return true;
 		} else {
-			return other instanceof ListTag && Objects.equals(value, ((ListTag) other).value);
+			return other instanceof ListTag otherList && value.equals(otherList.value);
 		}
 	}
 
@@ -438,11 +445,13 @@ public class ListTag extends CollectionTag<Tag> {
 		@SuppressWarnings("unchecked")
 		@Override
 		public T set(int index, T element) {
+			Objects.requireNonNull(element);
 			return (T) ListTag.this.set(index, element);
 		}
 
 		@Override
 		public void add(int index, T element) {
+			Objects.requireNonNull(element);
 			ListTag.this.add(index, element);
 		}
 

--- a/src/main/java/net/querz/nbt/LongArrayTag.java
+++ b/src/main/java/net/querz/nbt/LongArrayTag.java
@@ -4,12 +4,14 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 public class LongArrayTag extends CollectionTag<LongTag> {
 
 	private long[] value;
 
 	public LongArrayTag(long[] l) {
+		Objects.requireNonNull(l);
 		value = l;
 	}
 


### PR DESCRIPTION
Title says it all :)

NBT doesn't have a concept of `null`, and `CompoundTag` is clearly not designed for `null` keys or values.
In the interest of failing fast it'd be good to reject any rogue `null`'s upfront.

**Edit:** I also added a check to prevent `EndTag` values in `CompoundTag`. `ListTag`'s `updateType` already took care of this.