### PR TITLE
Fast-failing CompoundTag's and ListTag's getters

### DIFF
--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -183,87 +183,106 @@ public class CompoundTag implements Tag, Iterable<Map.Entry<String, Tag>> {
 	}
 
 	public byte getByteOrDefault(String key, byte def) {
-		if (contains(key, NUMBER)) {
-			return ((NumberTag) value.get(key)).asByte();
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.asByte();
 	}
 
 	public short getShortOrDefault(String key, short def) {
-		if (contains(key, NUMBER)) {
-			return ((NumberTag) value.get(key)).asShort();
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.asShort();
 	}
 
 	public int getIntOrDefault(String key, int def) {
-		if (contains(key, NUMBER)) {
-			return ((NumberTag) value.get(key)).asInt();
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.asInt();
 	}
 
 	public long getLongOrDefault(String key, long def) {
-		if (contains(key, NUMBER)) {
-			return ((NumberTag) value.get(key)).asLong();
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.asLong();
 	}
 
 	public float getFloatOrDefault(String key, float def) {
-		if (contains(key, NUMBER)) {
-			return ((NumberTag) value.get(key)).asFloat();
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.asFloat();
 	}
 
 	public double getDoubleOrDefault(String key, double def) {
-		if (contains(key, NUMBER)) {
-			return ((NumberTag) value.get(key)).asDouble();
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.asDouble();
 	}
 
 	public String getStringOrDefault(String key, String def) {
-		if (contains(key, STRING)) {
-			return ((StringTag) value.get(key)).getValue();
+		StringTag tag = getStringTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.getValue();
 	}
 
 	public byte[] getByteArrayOrDefault(String key, byte[] def) {
-		if (contains(key, BYTE_ARRAY)) {
-			return ((ByteArrayTag) value.get(key)).getValue();
+		ByteArrayTag tag = getByteArrayTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.getValue();
 	}
 
 	public int[] getIntArrayOrDefault(String key, int[] def) {
-		if (contains(key, INT_ARRAY)) {
-			return ((IntArrayTag) value.get(key)).getValue();
+		IntArrayTag tag = getIntArrayTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.getValue();
 	}
 
 	public long[] getLongArrayOrDefault(String key, long[] def) {
-		if (contains(key, LONG_ARRAY)) {
-			return ((LongArrayTag) value.get(key)).getValue();
+		LongArrayTag tag = getLongArrayTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag.getValue();
 	}
 
 	public CompoundTag getCompoundOrDefault(String key, CompoundTag def) {
-		if (contains(key, COMPOUND)) {
-			return (CompoundTag) value.get(key);
+		CompoundTag tag = getCompoundTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag;
 	}
 
 	public ListTag getListOrDefault(String key, ListTag def) {
-		if (contains(key, LIST)) {
-			return (ListTag) value.get(key);
+		ListTag tag = getListTag(key);
+		if (tag == null) {
+			return def;
 		}
-		return def;
+		return tag;
+	}
+
+	public NumberTag getNumberTag(String key) {
+		if (contains(key, NUMBER)) {
+			return (NumberTag) value.get(key);
+		}
+		return null;
 	}
 
 	public ByteTag getByteTag(String key) {

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -183,218 +183,170 @@ public class CompoundTag implements Tag, Iterable<Map.Entry<String, Tag>> {
 	}
 
 	public byte getByteOrDefault(String key, byte def) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asByte();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, NUMBER)) {
+			return ((NumberTag) value.get(key)).asByte();
+		}
 		return def;
 	}
 
 	public short getShortOrDefault(String key, short def) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asShort();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, NUMBER)) {
+			return ((NumberTag) value.get(key)).asShort();
+		}
 		return def;
 	}
 
 	public int getIntOrDefault(String key, int def) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asInt();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, NUMBER)) {
+			return ((NumberTag) value.get(key)).asInt();
+		}
 		return def;
 	}
 
 	public long getLongOrDefault(String key, long def) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asLong();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, NUMBER)) {
+			return ((NumberTag) value.get(key)).asLong();
+		}
 		return def;
 	}
 
 	public float getFloatOrDefault(String key, float def) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asFloat();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, NUMBER)) {
+			return ((NumberTag) value.get(key)).asFloat();
+		}
 		return def;
 	}
 
 	public double getDoubleOrDefault(String key, double def) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asDouble();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, NUMBER)) {
+			return ((NumberTag) value.get(key)).asDouble();
+		}
 		return def;
 	}
 
 	public String getStringOrDefault(String key, String def) {
-		try {
-			if (contains(key, STRING)) {
-				return ((StringTag) value.get(key)).getValue();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, STRING)) {
+			return ((StringTag) value.get(key)).getValue();
+		}
 		return def;
 	}
 
 	public byte[] getByteArrayOrDefault(String key, byte[] def) {
-		try {
-			if (contains(key, BYTE_ARRAY)) {
-				return ((ByteArrayTag) value.get(key)).getValue();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, BYTE_ARRAY)) {
+			return ((ByteArrayTag) value.get(key)).getValue();
+		}
 		return def;
 	}
 
 	public int[] getIntArrayOrDefault(String key, int[] def) {
-		try {
-			if (contains(key, INT_ARRAY)) {
-				return ((IntArrayTag) value.get(key)).getValue();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, INT_ARRAY)) {
+			return ((IntArrayTag) value.get(key)).getValue();
+		}
 		return def;
 	}
 
 	public long[] getLongArrayOrDefault(String key, long[] def) {
-		try {
-			if (contains(key, LONG_ARRAY)) {
-				return ((LongArrayTag) value.get(key)).getValue();
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, LONG_ARRAY)) {
+			return ((LongArrayTag) value.get(key)).getValue();
+		}
 		return def;
 	}
 
 	public CompoundTag getCompoundOrDefault(String key, CompoundTag def) {
-		try {
-			if (contains(key, COMPOUND)) {
-				return (CompoundTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, COMPOUND)) {
+			return (CompoundTag) value.get(key);
+		}
 		return def;
 	}
 
 	public ListTag getListOrDefault(String key, ListTag def) {
-		try {
-			if (contains(key, LIST)) {
-				return (ListTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, LIST)) {
+			return (ListTag) value.get(key);
+		}
 		return def;
 	}
 
 	public ByteTag getByteTag(String key) {
-		try {
-			if (contains(key, BYTE)) {
-				return (ByteTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, BYTE)) {
+			return (ByteTag) value.get(key);
+		}
 		return null;
 	}
 
 	public ShortTag getShortTag(String key) {
-		try {
-			if (contains(key, SHORT)) {
-				return (ShortTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, SHORT)) {
+			return (ShortTag) value.get(key);
+		}
 		return null;
 	}
 
 	public IntTag getIntTag(String key) {
-		try {
-			if (contains(key, INT)) {
-				return (IntTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, INT)) {
+			return (IntTag) value.get(key);
+		}
 		return null;
 	}
 
 	public LongTag getLongTag(String key) {
-		try {
-			if (contains(key, LONG)) {
-				return (LongTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, LONG)) {
+			return (LongTag) value.get(key);
+		}
 		return null;
 	}
 
 	public FloatTag getFloatTag(String key) {
-		try {
-			if (contains(key, FLOAT)) {
-				return (FloatTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, FLOAT)) {
+			return (FloatTag) value.get(key);
+		}
 		return null;
 	}
 
 	public DoubleTag getDoubleTag(String key) {
-		try {
-			if (contains(key, DOUBLE)) {
-				return (DoubleTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, DOUBLE)) {
+			return (DoubleTag) value.get(key);
+		}
 		return null;
 	}
 
 	public StringTag getStringTag(String key) {
-		try {
-			if (contains(key, STRING)) {
-				return (StringTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, STRING)) {
+			return (StringTag) value.get(key);
+		}
 		return null;
 	}
 
 	public ByteArrayTag getByteArrayTag(String key) {
-		try {
-			if (contains(key, BYTE_ARRAY)) {
-				return (ByteArrayTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, BYTE_ARRAY)) {
+			return (ByteArrayTag) value.get(key);
+		}
 		return null;
 	}
 
 	public IntArrayTag getIntArrayTag(String key) {
-		try {
-			if (contains(key, INT_ARRAY)) {
-				return (IntArrayTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, INT_ARRAY)) {
+			return (IntArrayTag) value.get(key);
+		}
 		return null;
 	}
 
 	public LongArrayTag getLongArrayTag(String key) {
-		try {
-			if (contains(key, LONG_ARRAY)) {
-				return (LongArrayTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, LONG_ARRAY)) {
+			return (LongArrayTag) value.get(key);
+		}
 		return null;
 	}
 
 	public ListTag getListTag(String key) {
-		try {
-			if (contains(key, LIST)) {
-				return (ListTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, LIST)) {
+			return (ListTag) value.get(key);
+		}
 		return null;
 	}
 
 	public CompoundTag getCompoundTag(String key) {
-		try {
-			if (contains(key, COMPOUND)) {
-				return (CompoundTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
+		if (contains(key, COMPOUND)) {
+			return (CompoundTag) value.get(key);
+		}
 		return null;
 	}
 

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -278,6 +278,10 @@ public class CompoundTag implements Tag, Iterable<Map.Entry<String, Tag>> {
 		return tag;
 	}
 
+	public boolean getBooleanOrDefault(String key, boolean b) {
+		return getByteOrDefault(key, (byte)(b ? 1 : 0)) != 0;
+	}
+
 	public NumberTag getNumberTag(String key) {
 		if (contains(key, NUMBER)) {
 			return (NumberTag) value.get(key);

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -127,111 +127,51 @@ public class CompoundTag implements Tag, Iterable<Map.Entry<String, Tag>> {
 	}
 
 	public byte getByte(String key) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asByte();
-			}
-		} catch (ClassCastException ex) {}
-		return 0;
+		return getByteOrDefault(key, (byte) 0);
 	}
 
 	public short getShort(String key) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asShort();
-			}
-		} catch (ClassCastException ex) {}
-		return 0;
+		return getShortOrDefault(key, (short) 0);
 	}
 
 	public int getInt(String key) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asInt();
-			}
-		} catch (ClassCastException ex) {}
-		return 0;
+		return getIntOrDefault(key, 0);
 	}
 
 	public long getLong(String key) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asLong();
-			}
-		} catch (ClassCastException ex) {}
-		return 0;
+		return getLongOrDefault(key, 0);
 	}
 
 	public float getFloat(String key) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asFloat();
-			}
-		} catch (ClassCastException ex) {}
-		return 0.0f;
+		return getFloatOrDefault(key, 0);
 	}
 
 	public double getDouble(String key) {
-		try {
-			if (contains(key, NUMBER)) {
-				return ((NumberTag) value.get(key)).asDouble();
-			}
-		} catch (ClassCastException ex) {}
-		return 0.0;
+		return getDoubleOrDefault(key, 0);
 	}
 
 	public String getString(String key) {
-		try {
-			if (contains(key, STRING)) {
-				return ((StringTag) value.get(key)).getValue();
-			}
-		} catch (ClassCastException ex) {}
-		return "";
+		return getStringOrDefault(key, "");
 	}
 
 	public byte[] getByteArray(String key) {
-		try {
-			if (contains(key, BYTE_ARRAY)) {
-				return ((ByteArrayTag) value.get(key)).getValue();
-			}
-		} catch (ClassCastException ex) {}
-		return new byte[0];
+		return getByteArrayOrDefault(key, new byte[0]);
 	}
 
 	public int[] getIntArray(String key) {
-		try {
-			if (contains(key, INT_ARRAY)) {
-				return ((IntArrayTag) value.get(key)).getValue();
-			}
-		} catch (ClassCastException ex) {}
-		return new int[0];
+		return getIntArrayOrDefault(key, new int[0]);
 	}
 
 	public long[] getLongArray(String key) {
-		try {
-			if (contains(key, LONG_ARRAY)) {
-				return ((LongArrayTag) value.get(key)).getValue();
-			}
-		} catch (ClassCastException ex) {}
-		return new long[0];
+		return getLongArrayOrDefault(key, new long[0]);
 	}
 
 	public CompoundTag getCompound(String key) {
-		try {
-			if (contains(key, COMPOUND)) {
-				return (CompoundTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
-		return new CompoundTag();
+		return getCompoundOrDefault(key, new CompoundTag());
 	}
 
 	public ListTag getList(String key) {
-		try {
-			if (contains(key, LIST)) {
-				return (ListTag) value.get(key);
-			}
-		} catch (ClassCastException ex) {}
-		return new ListTag();
+		return getListOrDefault(key, new ListTag());
 	}
 
 	public boolean getBoolean(String key) {

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -127,51 +127,99 @@ public class CompoundTag implements Tag, Iterable<Map.Entry<String, Tag>> {
 	}
 
 	public byte getByte(String key) {
-		return getByteOrDefault(key, (byte) 0);
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No numeric tag with key '"+key+"'");
+		}
+		return tag.asByte();
 	}
 
 	public short getShort(String key) {
-		return getShortOrDefault(key, (short) 0);
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No numeric tag with key '"+key+"'");
+		}
+		return tag.asShort();
 	}
 
 	public int getInt(String key) {
-		return getIntOrDefault(key, 0);
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No numeric tag with key '"+key+"'");
+		}
+		return tag.asInt();
 	}
 
 	public long getLong(String key) {
-		return getLongOrDefault(key, 0);
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No numeric tag with key '"+key+"'");
+		}
+		return tag.asLong();
 	}
 
 	public float getFloat(String key) {
-		return getFloatOrDefault(key, 0);
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No numeric tag with key '"+key+"'");
+		}
+		return tag.asFloat();
 	}
 
 	public double getDouble(String key) {
-		return getDoubleOrDefault(key, 0);
+		NumberTag tag = getNumberTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No numeric tag with key '"+key+"'");
+		}
+		return tag.asDouble();
 	}
 
 	public String getString(String key) {
-		return getStringOrDefault(key, "");
+		StringTag tag = getStringTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No string tag with key '"+key+"'");
+		}
+		return tag.getValue();
 	}
 
 	public byte[] getByteArray(String key) {
-		return getByteArrayOrDefault(key, new byte[0]);
+		ByteArrayTag tag = getByteArrayTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No byte array tag with key '"+key+"'");
+		}
+		return tag.getValue();
 	}
 
 	public int[] getIntArray(String key) {
-		return getIntArrayOrDefault(key, new int[0]);
+		IntArrayTag tag = getIntArrayTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No int array tag with key '"+key+"'");
+		}
+		return tag.getValue();
 	}
 
 	public long[] getLongArray(String key) {
-		return getLongArrayOrDefault(key, new long[0]);
+		LongArrayTag tag = getLongArrayTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No long array tag with key '"+key+"'");
+		}
+		return tag.getValue();
 	}
 
 	public CompoundTag getCompound(String key) {
-		return getCompoundOrDefault(key, new CompoundTag());
+		CompoundTag tag = getCompoundTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No compound tag with key '"+key+"'");
+		}
+		return tag;
 	}
 
 	public ListTag getList(String key) {
-		return getListOrDefault(key, new ListTag());
+		ListTag tag = getListTag(key);
+		if (tag == null) {
+			throw new NoSuchElementException("No byte array tag with key '"+key+"'");
+		}
+		return tag;
 	}
 
 	public boolean getBoolean(String key) {

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -174,52 +174,56 @@ public class ListTag extends CollectionTag<Tag> {
 		type = END;
 	}
 
+	private NumberTag getNumber(int index) {
+		return (NumberTag) value.get(index);
+	}
+
 	public byte getByte(int index) {
-		return getByteOrDefault(index, (byte) 0);
+		return getNumber(index).asByte();
 	}
 
 	public short getShort(int index) {
-		return getShortOrDefault(index, (short) 0);
+		return getNumber(index).asShort();
 	}
 
 	public int getInt(int index) {
-		return getIntOrDefault(index, 0);
+		return getNumber(index).asInt();
 	}
 
 	public long getLong(int index) {
-		return getLongOrDefault(index, 0);
+		return getNumber(index).asLong();
 	}
 
 	public float getFloat(int index) {
-		return getFloatOrDefault(index, 0);
+		return getNumber(index).asFloat();
 	}
 
 	public double getDouble(int index) {
-		return getDoubleOrDefault(index, 0);
+		return getNumber(index).asDouble();
 	}
 
 	public String getString(int index) {
-		return getStringOrDefault(index, "");
+		return ((StringTag) value.get(index)).getValue();
 	}
 
 	public byte[] getByteArray(int index) {
-		return getByteArrayOrDefault(index, new byte[0]);
+		return ((ByteArrayTag) value.get(index)).getValue();
 	}
 
 	public int[] getIntArray(int index) {
-		return getIntArrayOrDefault(index, new int[0]);
+		return ((IntArrayTag) value.get(index)).getValue();
 	}
 
 	public long[] getLongArray(int index) {
-		return getLongArrayOrDefault(index, new long[0]);
+		return ((LongArrayTag) value.get(index)).getValue();
 	}
 
 	public CompoundTag getCompound(int index) {
-		return getCompoundOrDefault(index, new CompoundTag());
+		return (CompoundTag) value.get(index);
 	}
 
 	public ListTag getList(int index) {
-		return getListOrDefault(index, new ListTag());
+		return (ListTag) value.get(index);
 	}
 
 	public boolean getBoolean(int index) {

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -175,123 +175,51 @@ public class ListTag extends CollectionTag<Tag> {
 	}
 
 	public byte getByte(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag instanceof NumberTag) {
-				return ((NumberTag) tag).asByte();
-			}
-		}
-		return 0;
+		return getByteOrDefault(index, (byte) 0);
 	}
 
 	public short getShort(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag instanceof NumberTag) {
-				return ((NumberTag) tag).asShort();
-			}
-		}
-		return 0;
+		return getShortOrDefault(index, (short) 0);
 	}
 
 	public int getInt(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag instanceof NumberTag) {
-				return ((NumberTag) tag).asInt();
-			}
-		}
-		return 0;
+		return getIntOrDefault(index, 0);
 	}
 
 	public long getLong(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag instanceof NumberTag) {
-				return ((NumberTag) tag).asLong();
-			}
-		}
-		return 0;
+		return getLongOrDefault(index, 0);
 	}
 
 	public float getFloat(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag instanceof NumberTag) {
-				return ((NumberTag) tag).asFloat();
-			}
-		}
-		return 0.0f;
+		return getFloatOrDefault(index, 0);
 	}
 
 	public double getDouble(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag instanceof NumberTag) {
-				return ((NumberTag) tag).asDouble();
-			}
-		}
-		return 0.0;
+		return getDoubleOrDefault(index, 0);
 	}
 
 	public String getString(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag.getID() == STRING) {
-				return ((StringTag) tag).getValue();
-			}
-		}
-		return "";
+		return getStringOrDefault(index, "");
 	}
 
 	public byte[] getByteArray(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag.getID() == BYTE_ARRAY) {
-				return ((ByteArrayTag) tag).getValue();
-			}
-		}
-		return new byte[0];
+		return getByteArrayOrDefault(index, new byte[0]);
 	}
 
 	public int[] getIntArray(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag.getID() == INT_ARRAY) {
-				return ((IntArrayTag) tag).getValue();
-			}
-		}
-		return new int[0];
+		return getIntArrayOrDefault(index, new int[0]);
 	}
 
 	public long[] getLongArray(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag.getID() == LONG_ARRAY) {
-				return ((LongArrayTag) tag).getValue();
-			}
-		}
-		return new long[0];
+		return getLongArrayOrDefault(index, new long[0]);
 	}
 
 	public CompoundTag getCompound(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag.getID() == COMPOUND) {
-				return (CompoundTag) tag;
-			}
-		}
-		return new CompoundTag();
+		return getCompoundOrDefault(index, new CompoundTag());
 	}
 
 	public ListTag getList(int index) {
-		if (index >= 0 && index < value.size()) {
-			Tag tag = value.get(index);
-			if (tag.getID() == LIST) {
-				return (ListTag) tag;
-			}
-		}
-		return new ListTag();
+		return getListOrDefault(index, new ListTag());
 	}
 
 	public boolean getBoolean(int index) {


### PR DESCRIPTION
Title says it all :)

I just spent _hours_ debugging something that was ultimately caused by missing (and then later wrong-kind) tags, because `CompoundTag` and `ListTag` implicitly supply default values. In the interest of failing-fast instead of propagating corrupted data I have removed this behavior.

Note that the previous behavior is still possible with the explicit `get*OrDefault` methods.
Failing-fast-checks are very tedious to write (and easy to forget!) with the current implementation on the other hand.