### PR TITLE
Fixing BiomeParser118 and BlockParser118

### DIFF
--- a/src/main/java/net/querz/mca/parsers/impl/anvil118/BiomeParser118.java
+++ b/src/main/java/net/querz/mca/parsers/impl/anvil118/BiomeParser118.java
@@ -150,14 +150,27 @@ public class BiomeParser118 implements BiomeParser<String> {
 		int newLength = (int) Math.ceil(64D / bytesPerLong);
 		newBiomes = data == null || newLength != data.length ? new long[newLength] : data;
 
-		int index = 0;
-		for (int i = 0; i < newLength; i++) {
+		for (int i = 0; i < newLength - 1; i++) {
 			long l = 0L;
-			for (int j = 0; j < bytesPerLong; j++, index++) {
-				l += parsedIndexes[index];
+			for (int j = 0; j < bytesPerLong - 1; j++) {
+				l += parsedIndexes[(i + 1) * bytesPerLong - j - 1];
 				l <<= numberOfBits;
 			}
+			l += parsedIndexes[i * bytesPerLong];
+
 			newBiomes[i] = l;
+		}
+		{
+			int i = newLength - 1;
+			long l = 0L;
+			int jm = 64 - (newLength - 1) * bytesPerLong;
+			for (int j = 0; j < jm - 1; j++) {
+				l += parsedIndexes[i * bytesPerLong + jm - j - 1];
+				l <<= numberOfBits;
+			}
+			l += parsedIndexes[i * bytesPerLong];
+
+			newBiomes[newLength - 1] = l;
 		}
 		data = newBiomes;
 		applyToHandle(palette, data);


### PR DESCRIPTION
I have no idea how the current variant came to be, it seems not to function for either 1.18 or above. I only looked into the block and biome parsers, as I needed only them. I haven't checked the others. The updated parsers should work for all 1.18+ versions