### PR TITLE
Restore Java 8 compatibility on the nbt7 branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ plugins {
 group 'net.querz'
 version '7.0'
 
-sourceCompatibility = JavaLanguageVersion.of(17)
-targetCompatibility = JavaLanguageVersion.of(17)
+sourceCompatibility = JavaLanguageVersion.of(8)
+targetCompatibility = JavaLanguageVersion.of(8)
 
 repositories {
     mavenCentral()

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,2 @@
 jdk:
-  - openjdk17
-
-before_install:
-  - sdk install java 17.0.3-ms
-  - sdk use java 17.0.3-ms
+  - openjdk8

--- a/src/main/java/net/querz/io/seekable/SeekableByteArray.java
+++ b/src/main/java/net/querz/io/seekable/SeekableByteArray.java
@@ -152,15 +152,19 @@ public class SeekableByteArray implements SeekableData {
 
 		while (!eol) {
 			switch (c = read()) {
-				case '\n' -> eol = true;
-				case '\r' -> {
+				case '\n':
+					eol = true;
+					break;
+				case '\r':
 					eol = true;
 					long cur = getPointer();
 					if (read() != '\n') {
 						seek(cur);
 					}
-				}
-				default -> sb.append((char) c);
+					break;
+				default:
+					sb.append((char) c);
+					break;
 			}
 		}
 

--- a/src/main/java/net/querz/mca/CompressionType.java
+++ b/src/main/java/net/querz/mca/CompressionType.java
@@ -52,15 +52,15 @@ public enum CompressionType {
 	}
 
 	public static CompressionType fromByte(int id) throws IOException {
-		return switch (id) {
-			case 0x0 -> NONE;
-			case 0x1 -> GZIP;
-			case 0x2 -> ZLIB;
-			case 0x80 -> NONE_EXT;
-			case 0x81 -> GZIP_EXT;
-			case 0x82 -> ZLIB_EXT;
-			default -> throw new IOException("invalid compression type " + id);
-		};
+		switch (id) {
+			case 0x0: return NONE;
+			case 0x1: return GZIP;
+			case 0x2: return ZLIB;
+			case 0x80: return NONE_EXT;
+			case 0x81: return GZIP_EXT;
+			case 0x82: return ZLIB_EXT;
+			default: throw new IOException("invalid compression type " + id);
+		}
 	}
 
 	@FunctionalInterface

--- a/src/main/java/net/querz/mca/MCAFileHandle.java
+++ b/src/main/java/net/querz/mca/MCAFileHandle.java
@@ -5,12 +5,55 @@ import net.querz.nbt.TagTypeVisitor;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.function.Supplier;
 
-public record MCAFileHandle(File directory, SeekableData seekableData, MCCFileHandler mccFileHandler, Supplier<TagTypeVisitor> tagTypeVisitorSupplier) implements AutoCloseable {
+public class MCAFileHandle implements AutoCloseable {
+
+	private final File directory;
+	private final SeekableData seekableData;
+	private final MCCFileHandler mccFileHandler;
+	private final Supplier<TagTypeVisitor> tagTypeVisitorSupplier;
+
+	public MCAFileHandle(File directory, SeekableData seekableData, MCCFileHandler mccFileHandler, Supplier<TagTypeVisitor> tagTypeVisitorSupplier) {
+		this.directory = directory;
+		this.seekableData = seekableData;
+		this.mccFileHandler = mccFileHandler;
+		this.tagTypeVisitorSupplier = tagTypeVisitorSupplier;
+	}
 
 	@Override
 	public void close() throws IOException {
 		seekableData.close();
 	}
+
+	public File directory() {
+		return directory;
+	}
+
+	public SeekableData seekableData() {
+		return seekableData;
+	}
+
+	public MCCFileHandler mccFileHandler() {
+		return mccFileHandler;
+	}
+
+	public Supplier<TagTypeVisitor> tagTypeVisitorSupplier() {
+		return tagTypeVisitorSupplier;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		MCAFileHandle that = (MCAFileHandle) o;
+		return Objects.equals(directory, that.directory) && Objects.equals(seekableData, that.seekableData) && Objects.equals(mccFileHandler, that.mccFileHandler) && Objects.equals(tagTypeVisitorSupplier, that.tagTypeVisitorSupplier);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(directory, seekableData, mccFileHandler, tagTypeVisitorSupplier);
+	}
+
 }

--- a/src/main/java/net/querz/mca/parsers/BlockLocation.java
+++ b/src/main/java/net/querz/mca/parsers/BlockLocation.java
@@ -1,8 +1,46 @@
 package net.querz.mca.parsers;
 
-public record BlockLocation(int x, int y, int z) {
+import java.util.Objects;
+
+public class BlockLocation {
+
+	private final int x;
+	private final int y;
+	private final int z;
+
+	public BlockLocation(int x, int y, int z) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
 
 	public BlockLocation() {
 		this(0, 0, 0);
 	}
+
+	public int x() {
+		return x;
+	}
+
+	public int y() {
+		return y;
+	}
+
+	public int z() {
+		return z;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		BlockLocation that = (BlockLocation) o;
+		return x == that.x && y == that.y && z == that.z;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(x, y, z);
+	}
+
 }

--- a/src/main/java/net/querz/mca/parsers/EntityLocation.java
+++ b/src/main/java/net/querz/mca/parsers/EntityLocation.java
@@ -1,8 +1,46 @@
 package net.querz.mca.parsers;
 
-public record EntityLocation(double x, double y, double z) {
+import java.util.Objects;
+
+public class EntityLocation {
+
+	private final double x;
+	private final double y;
+	private final double z;
+
+	public EntityLocation(double x, double y, double z) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
 
 	public EntityLocation() {
 		this(0, 0, 0);
 	}
+
+	public double x() {
+		return x;
+	}
+
+	public double y() {
+		return y;
+	}
+
+	public double z() {
+		return z;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		EntityLocation that = (EntityLocation) o;
+		return Double.compare(x, that.x) == 0 && Double.compare(y, that.y) == 0 && Double.compare(z, that.z) == 0;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(x, y, z);
+	}
+
 }

--- a/src/main/java/net/querz/mca/parsers/HeightmapParser.java
+++ b/src/main/java/net/querz/mca/parsers/HeightmapParser.java
@@ -1,5 +1,7 @@
 package net.querz.mca.parsers;
 
+import java.util.Arrays;
+
 public interface HeightmapParser extends DataParser<HeightmapParser.HeightmapData>, CachedParser {
 
 	HeightmapData getDataAt(int blockX, int blockZ);
@@ -43,10 +45,34 @@ public interface HeightmapParser extends DataParser<HeightmapParser.HeightmapDat
 		}
 	}
 
-	record HeightmapData(int[] data) {
+	class HeightmapData {
+
+		private final int[] data;
+
+		public HeightmapData(int[] data) {
+			this.data = data;
+		}
+
+		public int[] data() {
+			return data;
+		}
 
 		public int getHeight(HeightmapType type) {
 			return data[type.getID()];
 		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			HeightmapData that = (HeightmapData) o;
+			return Arrays.equals(data, that.data);
+		}
+
+		@Override
+		public int hashCode() {
+			return Arrays.hashCode(data);
+		}
+
 	}
 }

--- a/src/main/java/net/querz/nbt/ByteArrayTag.java
+++ b/src/main/java/net/querz/nbt/ByteArrayTag.java
@@ -110,7 +110,7 @@ public class ByteArrayTag extends CollectionTag<ByteTag> {
 		this.value = value;
 	}
 
-	public static final TagReader<ByteArrayTag> READER = new TagReader<>() {
+	public static final TagReader<ByteArrayTag> READER = new TagReader<ByteArrayTag>() {
 
 		@Override
 		public ByteArrayTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/ByteArrayTag.java
+++ b/src/main/java/net/querz/nbt/ByteArrayTag.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
-public non-sealed class ByteArrayTag extends CollectionTag<ByteTag> {
+public class ByteArrayTag extends CollectionTag<ByteTag> {
 
 	private byte[] value;
 

--- a/src/main/java/net/querz/nbt/ByteTag.java
+++ b/src/main/java/net/querz/nbt/ByteTag.java
@@ -4,7 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public non-sealed class ByteTag extends NumberTag {
+public class ByteTag extends NumberTag {
 
 	private final byte value;
 

--- a/src/main/java/net/querz/nbt/ByteTag.java
+++ b/src/main/java/net/querz/nbt/ByteTag.java
@@ -98,7 +98,7 @@ public class ByteTag extends NumberTag {
 		return value + "b";
 	}
 
-	public static final TagReader<ByteTag> READER = new TagReader<>() {
+	public static final TagReader<ByteTag> READER = new TagReader<ByteTag>() {
 
 		@Override
 		public ByteTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/CollectionTag.java
+++ b/src/main/java/net/querz/nbt/CollectionTag.java
@@ -2,7 +2,7 @@ package net.querz.nbt;
 
 import java.util.AbstractList;
 
-public sealed abstract class CollectionTag<T extends Tag> extends AbstractList<T> implements Tag permits ByteArrayTag, IntArrayTag, ListTag, LongArrayTag {
+public abstract class CollectionTag<T extends Tag> extends AbstractList<T> implements Tag {
 
 	public CollectionTag() {}
 

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -475,21 +475,20 @@ public class CompoundTag implements Tag, Map<String, Tag>, Iterable<Map.Entry<St
 			}
 			Tag tag = entry.getValue();
 			switch (tag.getType()) {
-				case COMPOUND -> {
-					CompoundTag otherTag = other.getCompoundTag(entry.getKey());
-					if (!((CompoundTag) tag).partOf(otherTag)) {
+				case COMPOUND:
+					CompoundTag otherCompound = other.getCompoundTag(entry.getKey());
+					if (!((CompoundTag) tag).partOf(otherCompound)) {
 						return false;
 					}
-				}
-				case LIST -> {
-					ListTag otherTag = other.getListTag(entry.getKey());
-					if (!((ListTag) tag).partOf(otherTag)) {
+					break;
+				case LIST:
+					ListTag otherList = other.getListTag(entry.getKey());
+					if (!((ListTag) tag).partOf(otherList)) {
 						return false;
 					}
-				}
-				default -> {
+					break;
+				default:
 					return tag.equals(other.get(entry.getKey()));
-				}
 			}
 		}
 		return true;
@@ -555,38 +554,35 @@ public class CompoundTag implements Tag, Map<String, Tag>, Iterable<Map.Entry<St
 				if ((id = in.readByte()) != END.id) {
 					TagReader<?> reader = valueOf(id).reader;
 					switch (visitor.visitEntry(reader)) {
-						case RETURN -> {
+						case RETURN:
 							return TagTypeVisitor.ValueResult.RETURN;
-						}
-						case BREAK -> {
+						case BREAK:
 							StringTag.skipUTF(in);
 							reader.skip(in);
-						}
-						case SKIP -> {
+							break;
+						case SKIP:
 							StringTag.skipUTF(in);
 							reader.skip(in);
 							continue;
-						}
-						default -> {
+						default:
 							String name = in.readUTF();
 							switch (visitor.visitEntry(reader, name)) {
-								case RETURN -> {
+								case RETURN:
 									return TagTypeVisitor.ValueResult.RETURN;
-								}
-								case BREAK -> reader.skip(in);
-								case SKIP -> {
+								case BREAK:
+									reader.skip(in);
+									break;
+								case SKIP:
 									reader.skip(in);
 									continue;
-								}
-								case ENTER -> {
+								case ENTER:
 									if (reader.read(in, visitor) == TagTypeVisitor.ValueResult.RETURN) {
 										return TagTypeVisitor.ValueResult.RETURN;
 									} else {
 										continue;
 									}
-								}
 							}
-						}
+							break;
 					}
 				}
 

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 import static net.querz.nbt.Tag.Type.*;
 
-public non-sealed class CompoundTag implements Tag, Map<String, Tag>, Iterable<Map.Entry<String, Tag>> {
+public class CompoundTag implements Tag, Map<String, Tag>, Iterable<Map.Entry<String, Tag>> {
 
 	private final Map<String, Tag> value;
 

--- a/src/main/java/net/querz/nbt/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/CompoundTag.java
@@ -529,7 +529,7 @@ public class CompoundTag implements Tag, Map<String, Tag>, Iterable<Map.Entry<St
 		return value.entrySet();
 	}
 
-	public static final TagReader<CompoundTag> READER = new TagReader<>() {
+	public static final TagReader<CompoundTag> READER = new TagReader<CompoundTag>() {
 
 		@Override
 		public CompoundTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/DoubleTag.java
+++ b/src/main/java/net/querz/nbt/DoubleTag.java
@@ -4,7 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public non-sealed class DoubleTag extends NumberTag {
+public class DoubleTag extends NumberTag {
 
 	private final double value;
 

--- a/src/main/java/net/querz/nbt/DoubleTag.java
+++ b/src/main/java/net/querz/nbt/DoubleTag.java
@@ -93,7 +93,7 @@ public class DoubleTag extends NumberTag {
 		return value + "d";
 	}
 
-	public static final TagReader<DoubleTag> READER = new TagReader<>() {
+	public static final TagReader<DoubleTag> READER = new TagReader<DoubleTag>() {
 
 		@Override
 		public DoubleTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/EndTag.java
+++ b/src/main/java/net/querz/nbt/EndTag.java
@@ -23,7 +23,7 @@ public class EndTag implements Tag {
 		visitor.visit(this);
 	}
 
-	public static final TagReader<EndTag> READER = new TagReader<>() {
+	public static final TagReader<EndTag> READER = new TagReader<EndTag>() {
 
 		@Override
 		public EndTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/EndTag.java
+++ b/src/main/java/net/querz/nbt/EndTag.java
@@ -4,7 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public non-sealed class EndTag implements Tag {
+public class EndTag implements Tag {
 
 	public static final EndTag INSTANCE = new EndTag();
 

--- a/src/main/java/net/querz/nbt/FloatTag.java
+++ b/src/main/java/net/querz/nbt/FloatTag.java
@@ -92,7 +92,7 @@ public class FloatTag extends NumberTag {
 		return value + "f";
 	}
 
-	public static final TagReader<FloatTag> READER = new TagReader<>() {
+	public static final TagReader<FloatTag> READER = new TagReader<FloatTag>() {
 
 		@Override
 		public FloatTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/FloatTag.java
+++ b/src/main/java/net/querz/nbt/FloatTag.java
@@ -4,7 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public non-sealed class FloatTag extends NumberTag {
+public class FloatTag extends NumberTag {
 
 	private final float value;
 

--- a/src/main/java/net/querz/nbt/IntArrayTag.java
+++ b/src/main/java/net/querz/nbt/IntArrayTag.java
@@ -112,7 +112,7 @@ public class IntArrayTag extends CollectionTag<IntTag> {
 		this.value = value;
 	}
 
-	public static final TagReader<IntArrayTag> READER = new TagReader<>() {
+	public static final TagReader<IntArrayTag> READER = new TagReader<IntArrayTag>() {
 
 		@Override
 		public IntArrayTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/IntArrayTag.java
+++ b/src/main/java/net/querz/nbt/IntArrayTag.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
-public non-sealed class IntArrayTag extends CollectionTag<IntTag> {
+public class IntArrayTag extends CollectionTag<IntTag> {
 
 	private int[] value;
 

--- a/src/main/java/net/querz/nbt/IntTag.java
+++ b/src/main/java/net/querz/nbt/IntTag.java
@@ -95,7 +95,7 @@ public class IntTag extends NumberTag {
 		return String.valueOf(value);
 	}
 
-	public static final TagReader<IntTag> READER = new TagReader<>() {
+	public static final TagReader<IntTag> READER = new TagReader<IntTag>() {
 
 		@Override
 		public IntTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/IntTag.java
+++ b/src/main/java/net/querz/nbt/IntTag.java
@@ -4,7 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public non-sealed class IntTag extends NumberTag {
+public class IntTag extends NumberTag {
 
 	private final int value;
 

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -76,7 +76,7 @@ public class ListTag extends CollectionTag<Tag> {
 			return false;
 		}
 		switch (type) {
-			case COMPOUND -> {
+			case COMPOUND:
 				loop:
 				for (CompoundTag tag : iterateType(CompoundTag.class)) {
 					for (CompoundTag otherTag : other.iterateType(CompoundTag.class)) {
@@ -86,8 +86,8 @@ public class ListTag extends CollectionTag<Tag> {
 					}
 					return false;
 				}
-			}
-			case LIST -> {
+				break;
+			case LIST:
 				loop:
 				for (ListTag tag : iterateType(ListTag.class)) {
 					for (ListTag otherTag : other.iterateType(ListTag.class)) {
@@ -97,8 +97,8 @@ public class ListTag extends CollectionTag<Tag> {
 					}
 					return false;
 				}
-			}
-			default -> {
+				break;
+			default:
 				loop:
 				for (Tag tag : this) {
 					for (Tag otherTag : other) {
@@ -108,7 +108,7 @@ public class ListTag extends CollectionTag<Tag> {
 					}
 					return false;
 				}
-			}
+				break;
 		}
 		return true;
 	}
@@ -476,36 +476,32 @@ public class ListTag extends CollectionTag<Tag> {
 			TagReader<?> reader = valueOf(in.readByte()).reader;
 			int length = in.readInt();
 			switch (visitor.visitList(reader, length)) {
-				case RETURN -> {
+				case RETURN:
 					return TagTypeVisitor.ValueResult.RETURN;
-				}
-				case BREAK -> {
+				case BREAK:
 					reader.skip(in);
 					return visitor.visitContainerEnd();
-				}
-				default -> {
+				default:
 					int i = 0;
 					loop:
 					for (; i < length; i++) {
 						switch (visitor.visitElement(reader, i)) {
-							case RETURN -> {
+							case RETURN:
 								return TagTypeVisitor.ValueResult.RETURN;
-							}
-							case BREAK -> {
+							case BREAK:
 								reader.skip(in);
 								break loop;
-							}
-							case SKIP -> reader.skip(in);
-							case ENTER -> {
+							case SKIP:
+								reader.skip(in);
+								break;
+							case ENTER:
 								switch (reader.read(in, visitor)) {
-									case RETURN -> {
+									case RETURN:
 										return TagTypeVisitor.ValueResult.RETURN;
-									}
-									case BREAK -> {
+									case BREAK:
 										break loop;
-									}
 								}
-							}
+								break;
 						}
 					}
 
@@ -518,7 +514,6 @@ public class ListTag extends CollectionTag<Tag> {
 					}
 
 					return visitor.visitContainerEnd();
-				}
 			}
 		}
 

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -219,7 +219,7 @@ public class ListTag extends CollectionTag<Tag> {
 		if (this == other) {
 			return true;
 		} else {
-			return other instanceof ListTag otherList && value.equals(otherList.value);
+			return other instanceof ListTag && value.equals(((ListTag) other).value);
 		}
 	}
 
@@ -453,7 +453,7 @@ public class ListTag extends CollectionTag<Tag> {
 
 	}
 
-	public static final TagReader<ListTag> READER = new TagReader<>() {
+	public static final TagReader<ListTag> READER = new TagReader<ListTag>() {
 
 		@Override
 		public ListTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/ListTag.java
+++ b/src/main/java/net/querz/nbt/ListTag.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 import static net.querz.nbt.Tag.Type.*;
 
-public non-sealed class ListTag extends CollectionTag<Tag> {
+public class ListTag extends CollectionTag<Tag> {
 
 	private final List<Tag> value;
 	private Type type;

--- a/src/main/java/net/querz/nbt/LongArrayTag.java
+++ b/src/main/java/net/querz/nbt/LongArrayTag.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
-public non-sealed class LongArrayTag extends CollectionTag<LongTag> {
+public class LongArrayTag extends CollectionTag<LongTag> {
 
 	private long[] value;
 

--- a/src/main/java/net/querz/nbt/LongArrayTag.java
+++ b/src/main/java/net/querz/nbt/LongArrayTag.java
@@ -112,7 +112,7 @@ public class LongArrayTag extends CollectionTag<LongTag> {
 		this.value = value;
 	}
 
-	public static final TagReader<LongArrayTag> READER = new TagReader<>() {
+	public static final TagReader<LongArrayTag> READER = new TagReader<LongArrayTag>() {
 
 		@Override
 		public LongArrayTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/LongTag.java
+++ b/src/main/java/net/querz/nbt/LongTag.java
@@ -95,7 +95,7 @@ public class LongTag extends NumberTag {
 		return value + "L";
 	}
 
-	public static final TagReader<LongTag> READER = new TagReader<>() {
+	public static final TagReader<LongTag> READER = new TagReader<LongTag>() {
 
 		@Override
 		public LongTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/LongTag.java
+++ b/src/main/java/net/querz/nbt/LongTag.java
@@ -4,7 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public non-sealed class LongTag extends NumberTag {
+public class LongTag extends NumberTag {
 
 	private final long value;
 

--- a/src/main/java/net/querz/nbt/NBTUtil.java
+++ b/src/main/java/net/querz/nbt/NBTUtil.java
@@ -247,14 +247,14 @@ public final class NBTUtil {
 			}
 		} else {
 			switch (visitor.visitRootEntry(reader)) {
-				case BREAK -> {
+				case BREAK:
 					StringTag.skipUTF(in);
 					reader.skip(in);
-				}
-				case CONTINUE -> {
+					break;
+				case CONTINUE:
 					StringTag.skipUTF(in);
 					reader.read(in, visitor);
-				}
+					break;
 			}
 		}
 	}

--- a/src/main/java/net/querz/nbt/NamedTag.java
+++ b/src/main/java/net/querz/nbt/NamedTag.java
@@ -1,3 +1,35 @@
 package net.querz.nbt;
 
-public record NamedTag(String name, Tag tag) {}
+import java.util.Objects;
+
+public class NamedTag {
+    private final String name;
+    private final Tag tag;
+
+    public NamedTag(String name, Tag tag) {
+        this.name = name;
+        this.tag = tag;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Tag tag() {
+        return tag;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NamedTag namedTag = (NamedTag) o;
+        return Objects.equals(name, namedTag.name) && Objects.equals(tag, namedTag.tag);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, tag);
+    }
+
+}

--- a/src/main/java/net/querz/nbt/NumberTag.java
+++ b/src/main/java/net/querz/nbt/NumberTag.java
@@ -1,6 +1,6 @@
 package net.querz.nbt;
 
-public sealed abstract class NumberTag implements Tag permits ByteTag, DoubleTag, FloatTag, IntTag, LongTag, ShortTag {
+public abstract class NumberTag implements Tag {
 
 	public abstract byte asByte();
 

--- a/src/main/java/net/querz/nbt/ShortTag.java
+++ b/src/main/java/net/querz/nbt/ShortTag.java
@@ -95,7 +95,7 @@ public class ShortTag extends NumberTag {
 		return value + "s";
 	}
 
-	public static final TagReader<ShortTag> READER = new TagReader<>() {
+	public static final TagReader<ShortTag> READER = new TagReader<ShortTag>() {
 
 		@Override
 		public ShortTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/ShortTag.java
+++ b/src/main/java/net/querz/nbt/ShortTag.java
@@ -4,7 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public non-sealed class ShortTag extends NumberTag {
+public class ShortTag extends NumberTag {
 
 	private final short value;
 

--- a/src/main/java/net/querz/nbt/StringTag.java
+++ b/src/main/java/net/querz/nbt/StringTag.java
@@ -4,7 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public non-sealed class StringTag implements Tag {
+public class StringTag implements Tag {
 
 	private final String value;
 

--- a/src/main/java/net/querz/nbt/StringTag.java
+++ b/src/main/java/net/querz/nbt/StringTag.java
@@ -55,7 +55,7 @@ public class StringTag implements Tag {
 		return value;
 	}
 
-	public static final TagReader<StringTag> READER = new TagReader<>() {
+	public static final TagReader<StringTag> READER = new TagReader<StringTag>() {
 
 		@Override
 		public StringTag read(DataInput in, int depth) throws IOException {

--- a/src/main/java/net/querz/nbt/Tag.java
+++ b/src/main/java/net/querz/nbt/Tag.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public sealed interface Tag permits CollectionTag, CompoundTag, EndTag, NumberTag, StringTag {
+public interface Tag {
 
 	int MAX_DEPTH = 512;
 

--- a/src/main/java/net/querz/nbt/io/NBTReader.java
+++ b/src/main/java/net/querz/nbt/io/NBTReader.java
@@ -123,14 +123,14 @@ public final class NBTReader {
 			}
 		} else {
 			switch (visitor.visitRootEntry(reader)) {
-				case BREAK -> {
+				case BREAK:
 					name = input.readUTF();
 					reader.skip(input);
-				}
-				case CONTINUE -> {
+					break;
+				case CONTINUE:
 					name = input.readUTF();
 					reader.read(input, visitor);
-				}
+					break;
 			}
 		}
 		return new NamedTag(name, visitor.getResult());

--- a/src/main/java/net/querz/nbt/io/snbt/SNBTReader.java
+++ b/src/main/java/net/querz/nbt/io/snbt/SNBTReader.java
@@ -19,7 +19,14 @@ public final class SNBTReader {
 	}
 
 	public Tag read(InputStream in) throws IOException {
-		String s = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+		// InputStream.readAllBytes is only available in Java 9 and beyond
+		ByteArrayOutputStream result = new ByteArrayOutputStream();
+		byte[] buffer = new byte[1024];
+		for (int length; (length = in.read(buffer)) != -1; ) {
+			result.write(buffer, 0, length);
+		}
+		String s = result.toString(StandardCharsets.UTF_8.name());
+
 		return new SNBTParser(s).parse(ignoreTrailing);
 	}
 

--- a/src/main/java/net/querz/nbt/io/snbt/SNBTWriter.java
+++ b/src/main/java/net/querz/nbt/io/snbt/SNBTWriter.java
@@ -15,7 +15,7 @@ public final class SNBTWriter {
 	}
 
 	public void write(OutputStream out, Tag tag) throws IOException {
-		PrintWriter writer = new PrintWriter(out, false, StandardCharsets.UTF_8);
+		PrintWriter writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8), false);
 		tag.accept(new SNBTWriterTagVisitor(writer, indent));
 		writer.flush();
 	}
@@ -28,7 +28,7 @@ public final class SNBTWriter {
 		try {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			write(baos, tag);
-			return baos.toString(StandardCharsets.UTF_8);
+			return baos.toString(StandardCharsets.UTF_8.name());
 		} catch (IOException ex) {
 			throw new UncheckedIOException(ex);
 		}

--- a/src/main/java/net/querz/nbt/io/snbt/SNBTWriterTagVisitor.java
+++ b/src/main/java/net/querz/nbt/io/snbt/SNBTWriterTagVisitor.java
@@ -31,7 +31,7 @@ public class SNBTWriterTagVisitor implements TagVisitor {
 	}
 
 	// region primitives
-	
+
 	@Override
 	public void visit(ByteTag t) {
 		writeNumber(t);
@@ -82,7 +82,7 @@ public class SNBTWriterTagVisitor implements TagVisitor {
 	// endregion
 
 	// region arrays
-	
+
 	@Override
 	public void visit(ByteArrayTag t) {
 		writeArray(t, "B");
@@ -113,7 +113,7 @@ public class SNBTWriterTagVisitor implements TagVisitor {
 			throw new UncheckedIOException(ex);
 		}
 	}
-	
+
 	// endregion
 
 	// region hierarchies
@@ -175,7 +175,11 @@ public class SNBTWriterTagVisitor implements TagVisitor {
 	}
 
 	private void writeIndent(int depth) throws IOException {
-		writer.write(indent.repeat(depth));
+		StringBuilder indent = new StringBuilder();
+		for (int i = 0; i < depth; i++) {
+			indent.append(this.indent);
+		}
+		writer.write(indent.toString());
 	}
 
 	// endregion

--- a/src/main/java/net/querz/nbt/io/stream/TagSelector.java
+++ b/src/main/java/net/querz/nbt/io/stream/TagSelector.java
@@ -1,6 +1,9 @@
 package net.querz.nbt.io.stream;
 
 import net.querz.nbt.TagReader;
+
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -16,15 +19,15 @@ public class TagSelector {
 	}
 
 	public TagSelector(String name, TagReader<?> reader) {
-		this(List.of(), name, reader);
+		this(Collections.emptyList(), name, reader);
 	}
 
 	public TagSelector(String p1, String name, TagReader<?> reader) {
-		this(List.of(p1), name, reader);
+		this(Collections.singletonList(p1), name, reader);
 	}
 
 	public TagSelector(String p1, String p2, String name, TagReader<?> reader) {
-		this(List.of(p1, p2), name, reader);
+		this(Arrays.asList(p1, p2), name, reader);
 	}
 
 	public List<String> path() {

--- a/src/main/java/net/querz/nbt/io/stream/TagSelector.java
+++ b/src/main/java/net/querz/nbt/io/stream/TagSelector.java
@@ -2,11 +2,18 @@ package net.querz.nbt.io.stream;
 
 import net.querz.nbt.TagReader;
 import java.util.List;
+import java.util.Objects;
 
-public record TagSelector (
-	List<String> path,
-	String name,
-	TagReader<?> type) {
+public class TagSelector {
+	private final List<String> path;
+	private final String name;
+	private final TagReader<?> type;
+
+	public TagSelector(List<String> path, String name, TagReader<?> type) {
+		this.path = path;
+		this.name = name;
+		this.type = type;
+	}
 
 	public TagSelector(String name, TagReader<?> reader) {
 		this(List.of(), name, reader);
@@ -19,4 +26,30 @@ public record TagSelector (
 	public TagSelector(String p1, String p2, String name, TagReader<?> reader) {
 		this(List.of(p1, p2), name, reader);
 	}
+
+	public List<String> path() {
+		return path;
+	}
+
+	public String name() {
+		return name;
+	}
+
+	public TagReader<?> type() {
+		return type;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		TagSelector that = (TagSelector) o;
+		return Objects.equals(path, that.path) && Objects.equals(name, that.name) && Objects.equals(type, that.type);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(path, name, type);
+	}
+
 }

--- a/src/main/java/net/querz/nbt/io/stream/TagTree.java
+++ b/src/main/java/net/querz/nbt/io/stream/TagTree.java
@@ -3,11 +3,18 @@ package net.querz.nbt.io.stream;
 import net.querz.nbt.TagReader;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
-public record TagTree(
-	int depth,
-	Map<String, TagTree> tree,
-	Map<String, TagReader<?>> selected) {
+public class TagTree {
+	private final int depth;
+	private final Map<String, TagTree> tree;
+	private final Map<String, TagReader<?>> selected;
+
+	public TagTree(int depth, Map<String, TagTree> tree, Map<String, TagReader<?>> selected) {
+		this.depth = depth;
+		this.tree = tree;
+		this.selected = selected;
+	}
 
 	/**
 	 * Creates a new TagTree root element with {@code depth = 1}.
@@ -41,4 +48,30 @@ public record TagTree(
 	public boolean isSelected(String name, TagReader<?> reader) {
 		return reader.equals(selected.get(name));
 	}
+
+	public int depth() {
+		return depth;
+	}
+
+	public Map<String, TagTree> tree() {
+		return tree;
+	}
+
+	public Map<String, TagReader<?>> selected() {
+		return selected;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		TagTree tagTree = (TagTree) o;
+		return depth == tagTree.depth && Objects.equals(tree, tagTree.tree) && Objects.equals(selected, tagTree.selected);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(depth, tree, selected);
+	}
+
 }

--- a/src/test/java/net/querz/NBTTestCase.java
+++ b/src/test/java/net/querz/NBTTestCase.java
@@ -177,19 +177,33 @@ public abstract class NBTTestCase {
 		StringBuilder sb = new StringBuilder();
 
 		switch (tag.getType()) {
-			case END -> {}
-			case BYTE -> sb.append("ByteTag byteTag").append(c).append(" = ByteTag.valueOf((byte) ").append(((ByteTag) tag).asByte()).append(");");
-			case SHORT -> sb.append("ShortTag shortTag").append(c).append(" = ShortTag.valueOf((short) ").append(((ShortTag) tag).asShort()).append(");");
-			case INT -> sb.append("IntTag intTag").append(c).append(" = IntTag.valueOf(").append(((IntTag) tag).asInt()).append(");");
-			case LONG -> sb.append("LongTag longTag").append(c).append(" = LongTag.valueOf(").append(((LongTag) tag).asLong()).append("L);");
-			case FLOAT -> sb.append("FloatTag floatTag").append(c).append(" = FloatTag.valueOf(").append(((FloatTag) tag).asFloat()).append("F);");
-			case DOUBLE -> sb.append("DoubleTag doubleTag").append(c).append(" = DoubleTag.valueOf(").append(((DoubleTag) tag).asDouble()).append("D);");
-			case BYTE_ARRAY -> {
-				String asString = Arrays.toString(((ByteArrayTag) tag).getValue());
-				sb.append("ByteArrayTag byteArrayTag").append(c).append(" = new ByteArrayTag(new byte[]{").append(asString, 1, asString.length() - 1).append("});");
-			}
-			case STRING -> sb.append("StringTag stringTag").append(c).append(" = StringTag.valueOf(\"").append(((StringTag) tag).getValue().replace("\\", "\\\\").replace("\"", "\\\"")).append("\");");
-			case LIST -> {
+			case END: break;
+			case BYTE:
+				sb.append("ByteTag byteTag").append(c).append(" = ByteTag.valueOf((byte) ").append(((ByteTag) tag).asByte()).append(");");
+				break;
+			case SHORT:
+				sb.append("ShortTag shortTag").append(c).append(" = ShortTag.valueOf((short) ").append(((ShortTag) tag).asShort()).append(");");
+				break;
+			case INT:
+				sb.append("IntTag intTag").append(c).append(" = IntTag.valueOf(").append(((IntTag) tag).asInt()).append(");");
+				break;
+			case LONG:
+				sb.append("LongTag longTag").append(c).append(" = LongTag.valueOf(").append(((LongTag) tag).asLong()).append("L);");
+				break;
+			case FLOAT:
+				sb.append("FloatTag floatTag").append(c).append(" = FloatTag.valueOf(").append(((FloatTag) tag).asFloat()).append("F);");
+				break;
+			case DOUBLE:
+				sb.append("DoubleTag doubleTag").append(c).append(" = DoubleTag.valueOf(").append(((DoubleTag) tag).asDouble()).append("D);");
+				break;
+			case BYTE_ARRAY:
+				String asStringBytes = Arrays.toString(((ByteArrayTag) tag).getValue());
+				sb.append("ByteArrayTag byteArrayTag").append(c).append(" = new ByteArrayTag(new byte[]{").append(asStringBytes, 1, asStringBytes.length() - 1).append("});");
+				break;
+			case STRING:
+				sb.append("StringTag stringTag").append(c).append(" = StringTag.valueOf(\"").append(((StringTag) tag).getValue().replace("\\", "\\\\").replace("\"", "\\\"")).append("\");");
+				break;
+			case LIST:
 				String name = "listTag" + c.getAndIncrement();
 				sb.append("ListTag ").append(name).append(" = new ListTag();").append(((ListTag) tag).isEmpty() ? "" : "\n");;
 				int i = ((ListTag) tag).size();
@@ -200,33 +214,31 @@ public abstract class NBTTestCase {
 					String val = es.split(" ", 3)[1];
 					sb.append(name).append(".add(").append(val).append(");").append(--i > 0 ? "\n" : "");
 				}
-			}
-			case COMPOUND -> {
-				String name = "compoundTag" + c.getAndIncrement();
-				sb.append("CompoundTag ").append(name).append(" = new CompoundTag();").append(((CompoundTag) tag).isEmpty() ? "" : "\n");
-				int i = ((CompoundTag) tag).size();
+				break;
+			case COMPOUND:
+				String nameCompound = "compoundTag" + c.getAndIncrement();
+				sb.append("CompoundTag ").append(nameCompound).append(" = new CompoundTag();").append(((CompoundTag) tag).isEmpty() ? "" : "\n");
+				int j = ((CompoundTag) tag).size();
 				for (Map.Entry<String, Tag> e : (CompoundTag) tag) {
 					c.incrementAndGet();
 					String es = tagToCode(e.getValue(), c);
 					sb.append(es).append("\n");
 					String val = es.split(" ", 3)[1];
-					sb.append(name).append(".put(\"").append(e.getKey().replace("\\", "\\\\").replace("\"", "\\\"")).append("\", ").append(val).append(");").append(--i > 0 ? "\n" : "");
+					sb.append(nameCompound).append(".put(\"").append(e.getKey().replace("\\", "\\\\").replace("\"", "\\\"")).append("\", ").append(val).append(");").append(--j > 0 ? "\n" : "");
 				}
-
-			}
-			case INT_ARRAY -> {
-				String asString = Arrays.toString(((IntArrayTag) tag).getValue());
-				sb.append("IntArrayTag intArrayTag").append(c).append(" = new IntArrayTag(new int[]{").append(asString, 1, asString.length() - 1).append("});");
-			}
-			case LONG_ARRAY -> {
+				break;
+			case INT_ARRAY:
+				String asStringInts = Arrays.toString(((IntArrayTag) tag).getValue());
+				sb.append("IntArrayTag intArrayTag").append(c).append(" = new IntArrayTag(new int[]{").append(asStringInts, 1, asStringInts.length() - 1).append("});");
+				break;
+			case LONG_ARRAY:
 				sb.append("LongArrayTag longArrayTag").append(c).append(" = new LongArrayTag(new long[]{");
 				long[] value = ((LongArrayTag) tag).getValue();
-				for (int i = 0; i < value.length; i++) {
-					sb.append(i == 0 ? "" : ", ").append(value[i]).append("L");
+				for (int k = 0; k < value.length; k++) {
+					sb.append(k == 0 ? "" : ", ").append(value[k]).append("L");
 				}
 				sb.append("});");
-			}
-
+				break;
 		}
 		return sb.toString();
 	}

--- a/src/test/java/net/querz/nbt/TestNBTUtil.java
+++ b/src/test/java/net/querz/nbt/TestNBTUtil.java
@@ -8,6 +8,7 @@ import net.querz.nbt.io.stream.TagSelector;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.util.Arrays;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,7 +42,7 @@ public class TestNBTUtil extends NBTTestCase {
 		}
 
 		try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(raw))) {
-			t = NBTUtil.parseStream(dis, new TagSelector(List.of("Data", "Player", "Attributes"), "Name", StringTag.READER));
+			t = NBTUtil.parseStream(dis, new TagSelector(Arrays.asList("Data", "Player", "Attributes"), "Name", StringTag.READER));
 
 			System.out.println(NBTUtil.toSNBT(t, "\t"));
 		}
@@ -106,7 +107,7 @@ public class TestNBTUtil extends NBTTestCase {
 
 
 
-	
+
 
 
 


### PR DESCRIPTION
This one is a bit out there, but I figured I might as well submit a PR on the off-chance it gets accepted.

I'd like to use this great library in [AdvancedBackups](https://github.com/MommyHeather/AdvancedBackups), which needs to support Java 8 for ancient Minecraft versions. We could use a fork for this, but perhaps the syntax sugar downgrade is insignificant enough to be accepted into upstream?

No hard feelings if you don't want to accept this one, not sure I would in your position either :)